### PR TITLE
Extend world ranking numbers and fixes to CQUI.modinfo

### DIFF
--- a/Assets/Text/cqui_InGameText.xml
+++ b/Assets/Text/cqui_InGameText.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<GameData>
+	<BaseGameText>
+    <!-- oerms: This file extends the vanilla InGameText.xml -->
+  
+    <!-- Extended variables for world ranking from 20 to 30 players -->
+		<Row Tag="LOC_WORLD_RANKINGS_21_PLACE">
+			<Text>twenty-first</Text>
+		</Row>
+    <Row Tag="LOC_WORLD_RANKINGS_22_PLACE">
+			<Text>twenty-second</Text>
+		</Row>
+    <Row Tag="LOC_WORLD_RANKINGS_23_PLACE">
+			<Text>twenty-third</Text>
+		</Row>
+    <Row Tag="LOC_WORLD_RANKINGS_24_PLACE">
+			<Text>twenty-fourth</Text>
+		</Row>
+    <Row Tag="LOC_WORLD_RANKINGS_25_PLACE">
+			<Text>twenty-fifth</Text>
+		</Row>
+    <Row Tag="LOC_WORLD_RANKINGS_26_PLACE">
+			<Text>twenty-sixth</Text>
+		</Row>
+    <Row Tag="LOC_WORLD_RANKINGS_27_PLACE">
+			<Text>twenty-seventh</Text>
+		</Row>
+    <Row Tag="LOC_WORLD_RANKINGS_28_PLACE">
+			<Text>twenty-eighth</Text>
+		</Row>
+    <Row Tag="LOC_WORLD_RANKINGS_29_PLACE">
+			<Text>twenty-ninth</Text>
+		</Row>
+    <Row Tag="LOC_WORLD_RANKINGS_30_PLACE">
+			<Text>thirtieth</Text>
+		</Row>
+ 	</BaseGameText>
+</GameData>

--- a/Assets/Text/cqui_InGameText.xml
+++ b/Assets/Text/cqui_InGameText.xml
@@ -1,38 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
 <GameData>
-	<BaseGameText>
+	<LocalizedText>
     <!-- oerms: This file extends the vanilla InGameText.xml -->
-  
     <!-- Extended variables for world ranking from 20 to 30 players -->
-		<Row Tag="LOC_WORLD_RANKINGS_21_PLACE">
+		<Row Tag="LOC_WORLD_RANKINGS_21_PLACE" Language="en_US">
 			<Text>twenty-first</Text>
 		</Row>
-    <Row Tag="LOC_WORLD_RANKINGS_22_PLACE">
+    <Row Tag="LOC_WORLD_RANKINGS_22_PLACE" Language="en_US">
 			<Text>twenty-second</Text>
 		</Row>
-    <Row Tag="LOC_WORLD_RANKINGS_23_PLACE">
+    <Row Tag="LOC_WORLD_RANKINGS_23_PLACE" Language="en_US">
 			<Text>twenty-third</Text>
 		</Row>
-    <Row Tag="LOC_WORLD_RANKINGS_24_PLACE">
+    <Row Tag="LOC_WORLD_RANKINGS_24_PLACE" Language="en_US">
 			<Text>twenty-fourth</Text>
 		</Row>
-    <Row Tag="LOC_WORLD_RANKINGS_25_PLACE">
+    <Row Tag="LOC_WORLD_RANKINGS_25_PLACE" Language="en_US">
 			<Text>twenty-fifth</Text>
 		</Row>
-    <Row Tag="LOC_WORLD_RANKINGS_26_PLACE">
+    <Row Tag="LOC_WORLD_RANKINGS_26_PLACE" Language="en_US">
 			<Text>twenty-sixth</Text>
 		</Row>
-    <Row Tag="LOC_WORLD_RANKINGS_27_PLACE">
+    <Row Tag="LOC_WORLD_RANKINGS_27_PLACE" Language="en_US">
 			<Text>twenty-seventh</Text>
 		</Row>
-    <Row Tag="LOC_WORLD_RANKINGS_28_PLACE">
+    <Row Tag="LOC_WORLD_RANKINGS_28_PLACE" Language="en_US">
 			<Text>twenty-eighth</Text>
 		</Row>
-    <Row Tag="LOC_WORLD_RANKINGS_29_PLACE">
+    <Row Tag="LOC_WORLD_RANKINGS_29_PLACE" Language="en_US">
 			<Text>twenty-ninth</Text>
 		</Row>
-    <Row Tag="LOC_WORLD_RANKINGS_30_PLACE">
+    <Row Tag="LOC_WORLD_RANKINGS_30_PLACE" Language="en_US">
 			<Text>thirtieth</Text>
 		</Row>
- 	</BaseGameText>
+ 	</LocalizedText>
 </GameData>

--- a/Assets/Text/cqui_InGameText_de.xml
+++ b/Assets/Text/cqui_InGameText_de.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<GameData>
+	<LocalizedText>
+    <!-- oerms: This file extends the vanilla InGameText.xml -->
+    <!-- Extended variables for world ranking from 20 to 30 players -->
+		<Row Tag="LOC_WORLD_RANKINGS_21_PLACE" Language="de_DE">
+			<Text>einundzwanzigstem</Text>
+		</Row>
+    <Row Tag="LOC_WORLD_RANKINGS_22_PLACE" Language="de_DE">
+			<Text>zweiundzwanzigstem</Text>
+		</Row>
+    <Row Tag="LOC_WORLD_RANKINGS_23_PLACE" Language="de_DE">
+			<Text>dreiundzwanzigstem</Text>
+		</Row>
+    <Row Tag="LOC_WORLD_RANKINGS_24_PLACE" Language="de_DE">
+			<Text>vierundzwanzigstem</Text>
+		</Row>
+    <Row Tag="LOC_WORLD_RANKINGS_25_PLACE" Language="de_DE">
+			<Text>fünfundzwanzigstem</Text>
+		</Row>
+    <Row Tag="LOC_WORLD_RANKINGS_26_PLACE" Language="de_DE">
+			<Text>sechsundzwanzigstem</Text>
+		</Row>
+    <Row Tag="LOC_WORLD_RANKINGS_27_PLACE" Language="de_DE">
+			<Text>siebenundzwanzigstem</Text>
+		</Row>
+    <Row Tag="LOC_WORLD_RANKINGS_28_PLACE" Language="de_DE">
+			<Text>achtundzwanzigstem</Text>
+		</Row>
+    <Row Tag="LOC_WORLD_RANKINGS_29_PLACE" Language="de_DE">
+			<Text>neunundzwanzigstem</Text>
+		</Row>
+    <Row Tag="LOC_WORLD_RANKINGS_30_PLACE" Language="de_DE">
+			<Text>dreißigstem</Text>
+		</Row>
+ 	</LocalizedText>
+</GameData>

--- a/Assets/Text/cqui_InGameText_de.xml
+++ b/Assets/Text/cqui_InGameText_de.xml
@@ -4,34 +4,34 @@
     <!-- oerms: This file extends the vanilla InGameText.xml -->
     <!-- Extended variables for world ranking from 20 to 30 players -->
 		<Row Tag="LOC_WORLD_RANKINGS_21_PLACE" Language="de_DE">
-			<Text>einundzwanzigstem</Text>
+			<Text>einundzwanzigsten</Text>
 		</Row>
     <Row Tag="LOC_WORLD_RANKINGS_22_PLACE" Language="de_DE">
-			<Text>zweiundzwanzigstem</Text>
+			<Text>zweiundzwanzigsten</Text>
 		</Row>
     <Row Tag="LOC_WORLD_RANKINGS_23_PLACE" Language="de_DE">
-			<Text>dreiundzwanzigstem</Text>
+			<Text>dreiundzwanzigsten</Text>
 		</Row>
     <Row Tag="LOC_WORLD_RANKINGS_24_PLACE" Language="de_DE">
-			<Text>vierundzwanzigstem</Text>
+			<Text>vierundzwanzigsten</Text>
 		</Row>
     <Row Tag="LOC_WORLD_RANKINGS_25_PLACE" Language="de_DE">
-			<Text>fünfundzwanzigstem</Text>
+			<Text>fünfundzwanzigsten</Text>
 		</Row>
     <Row Tag="LOC_WORLD_RANKINGS_26_PLACE" Language="de_DE">
-			<Text>sechsundzwanzigstem</Text>
+			<Text>sechsundzwanzigsten</Text>
 		</Row>
     <Row Tag="LOC_WORLD_RANKINGS_27_PLACE" Language="de_DE">
-			<Text>siebenundzwanzigstem</Text>
+			<Text>siebenundzwanzigsten</Text>
 		</Row>
     <Row Tag="LOC_WORLD_RANKINGS_28_PLACE" Language="de_DE">
-			<Text>achtundzwanzigstem</Text>
+			<Text>achtundzwanzigsten</Text>
 		</Row>
     <Row Tag="LOC_WORLD_RANKINGS_29_PLACE" Language="de_DE">
-			<Text>neunundzwanzigstem</Text>
+			<Text>neunundzwanzigsten</Text>
 		</Row>
     <Row Tag="LOC_WORLD_RANKINGS_30_PLACE" Language="de_DE">
-			<Text>dreißigstem</Text>
+			<Text>dreißigsten</Text>
 		</Row>
  	</LocalizedText>
 </GameData>

--- a/CQUI.modinfo
+++ b/CQUI.modinfo
@@ -48,6 +48,7 @@
     <File>Assets/Text/Gossip_Text.xml</File>
     <File>Assets/Text/Gossip_Text_pt.xml</File>
     <File>Assets/Text/cqui_InGameText.xml</File>
+    <File>Assets/Text/cqui_InGameText_de.xml</File>
     <File>Assets/Text/cqui_text_general.xml</File>
     <File>Assets/Text/cqui_text_general_de.xml</File>
     <File>Assets/Text/cqui_text_general_fr.xml</File>
@@ -274,26 +275,30 @@
       <Items>
 	    <File>Assets/Text/Gossip_Text.xml</File>
         <File>Assets/Text/Gossip_Text_pt.xml</File>
+        <File>Assets/Text/cqui_InGameText.xml</File>
+        <File>Assets/Text/cqui_InGameText_de.xml</File>
         <File>Assets/Text/cqui_text_general.xml</File>
         <File>Assets/Text/cqui_text_general_de.xml</File>
+        <File>Assets/Text/cqui_text_general_es.xml</File>
         <File>Assets/Text/cqui_text_general_fr.xml</File>
         <File>Assets/Text/cqui_text_general_it.xml</File>
+        <File>Assets/Text/cqui_text_general_ja.xml</File>
         <File>Assets/Text/cqui_text_general_ko.xml</File>
         <File>Assets/Text/cqui_text_general_pl.xml</File>
+        <File>Assets/Text/cqui_text_general_pt.xml</File>
         <File>Assets/Text/cqui_text_general_ru.xml</File>
         <File>Assets/Text/cqui_text_general_zh.xml</File>
-        <File>Assets/Text/cqui_text_general_es.xml</File>
-        <File>Assets/Text/cqui_text_general_pt.xml</File>
         <File>Assets/Text/cqui_text_settings.xml</File>
         <File>Assets/Text/cqui_text_settings_de.xml</File>
+        <File>Assets/Text/cqui_text_settings_es.xml</File>
         <File>Assets/Text/cqui_text_settings_fr.xml</File>
         <File>Assets/Text/cqui_text_settings_it.xml</File>
+        <File>Assets/Text/cqui_text_settings_ja.xml</File>
         <File>Assets/Text/cqui_text_settings_ko.xml</File>
         <File>Assets/Text/cqui_text_settings_pl.xml</File>
+        <File>Assets/Text/cqui_text_settings_pt.xml</File>
         <File>Assets/Text/cqui_text_settings_ru.xml</File>
         <File>Assets/Text/cqui_text_settings_zh.xml</File>
-        <File>Assets/Text/cqui_text_settings_es.xml</File>
-        <File>Assets/Text/cqui_text_settings_pt.xml</File>
       </Items>
     </LocalizedText>
 	
@@ -341,14 +346,15 @@
       <Items>
         <File>Integrations/BTS/Text/bts_text.xml</File>
         <File>Integrations/BTS/Text/bts_text_de.xml</File>
+        <File>Integrations/BTS/Text/bts_text_es.xml</File>
         <File>Integrations/BTS/Text/bts_text_fr.xml</File>
         <File>Integrations/BTS/Text/bts_text_it.xml</File>
+        <File>Integrations/BTS/Text/bts_text_ja.xml</File>
         <File>Integrations/BTS/Text/bts_text_ko.xml</File>
         <File>Integrations/BTS/Text/bts_text_pl.xml</File>
+        <File>Integrations/BTS/Text/bts_text_pt.xml</File>
         <File>Integrations/BTS/Text/bts_text_ru.xml</File>
         <File>Integrations/BTS/Text/bts_text_zh.xml</File>
-        <File>Integrations/BTS/Text/bts_text_es.xml</File>
-        <File>Integrations/BTS/Text/bts_text_pt.xml</File>
       </Items>
     </LocalizedText>
     <ImportFiles id="BTS_IMPORT_FILES">
@@ -366,14 +372,15 @@
       <Items>
         <File>Integrations/URS/Text/urs_text.xml</File>
         <File>Integrations/URS/Text/urs_text_de.xml</File>
+        <File>Integrations/URS/Text/urs_text_es.xml</File>
         <File>Integrations/URS/Text/urs_text_fr.xml</File>
         <File>Integrations/URS/Text/urs_text_it.xml</File>
+        <File>Integrations/URS/Text/urs_text_ja.xml</File>
         <File>Integrations/URS/Text/urs_text_ko.xml</File>
         <File>Integrations/URS/Text/urs_text_pl.xml</File>
+        <File>Integrations/URS/Text/urs_text_pt.xml</File>
         <File>Integrations/URS/Text/urs_text_ru.xml</File>
         <File>Integrations/URS/Text/urs_text_zh.xml</File>
-        <File>Integrations/URS/Text/urs_text_es.xml</File>
-        <File>Integrations/URS/Text/urs_text_pt.xml</File>
       </Items>
     </LocalizedText>
     <ImportFiles id="UNITREPORT_IMPORT_FILES">
@@ -393,14 +400,15 @@
       <Items>
         <File>Integrations/IDS/Text/ids_text.xml</File>
         <File>Integrations/IDS/Text/ids_text_de.xml</File>
+        <File>Integrations/IDS/Text/ids_text_es.xml</File>
         <File>Integrations/IDS/Text/ids_text_fr.xml</File>
         <File>Integrations/IDS/Text/ids_text_it.xml</File>
+        <File>Integrations/IDS/Text/ids_text_ja.xml</File>
         <File>Integrations/IDS/Text/ids_text_ko.xml</File>
         <File>Integrations/IDS/Text/ids_text_pl.xml</File>
+        <File>Integrations/IDS/Text/ids_text_pt.xml</File>
         <File>Integrations/IDS/Text/ids_text_ru.xml</File>
         <File>Integrations/IDS/Text/ids_text_zh.xml</File>
-        <File>Integrations/IDS/Text/ids_text_es.xml</File>
-        <File>Integrations/IDS/Text/ids_text_pt.xml</File>
       </Items>
     </LocalizedText>
   <ImportFiles id="BES_IMPORT_FILES">
@@ -415,6 +423,12 @@
     <LocalizedText id="BES_TEXT">
       <Items>
         <File>Integrations/BES/Text/bes_text.xml</File>
+        <File>Integrations/BES/Text/bes_text_de.xml</File>
+        <File>Integrations/BES/Text/bes_text_es.xml</File>
+        <File>Integrations/BES/Text/bes_text_it.xml</File>
+        <File>Integrations/BES/Text/bes_text_ja.xml</File>
+        <File>Integrations/BES/Text/bes_text_pt.xml</File>
+        <File>Integrations/BES/Text/bes_text_ru.xml</File>
       </Items>
     </LocalizedText>
     <ImportFiles id="MORELENSES_IMPORT_FILES">
@@ -429,14 +443,15 @@
       <Items>
         <File>Integrations/ML/Text/morelenses_text.xml</File>
         <File>Integrations/ML/Text/morelenses_text_de.xml</File>
+        <File>Integrations/ML/Text/morelenses_text_es.xml</File>
         <File>Integrations/ML/Text/morelenses_text_fr.xml</File>
         <File>Integrations/ML/Text/morelenses_text_it.xml</File>
+        <File>Integrations/ML/Text/morelenses_text_ja.xml</File>
         <File>Integrations/ML/Text/morelenses_text_ko.xml</File>
         <File>Integrations/ML/Text/morelenses_text_pl.xml</File>
+        <File>Integrations/ML/Text/morelenses_text_pt.xml</File>
         <File>Integrations/ML/Text/morelenses_text_ru.xml</File>
         <File>Integrations/ML/Text/morelenses_text_zh.xml</File>
-        <File>Integrations/ML/Text/morelenses_text_es.xml</File>
-        <File>Integrations/ML/Text/morelenses_text_pt.xml</File>
       </Items>
     </LocalizedText>
     <UpdateDatabase id="MORELENSES_DATABASE">

--- a/CQUI.modinfo
+++ b/CQUI.modinfo
@@ -47,6 +47,7 @@
     <File>Assets/cqui_toplayer.lua</File>
     <File>Assets/Text/Gossip_Text.xml</File>
     <File>Assets/Text/Gossip_Text_pt.xml</File>
+    <File>Assets/Text/cqui_InGameText.xml</File>
     <File>Assets/Text/cqui_text_general.xml</File>
     <File>Assets/Text/cqui_text_general_de.xml</File>
     <File>Assets/Text/cqui_text_general_fr.xml</File>


### PR DESCRIPTION
Extended LOC_ variables to accomodate for many players and rankings lower than 20. See vtmatt's comment in #152. (30 Players should be enough as there are only 26 civs including all DLC.)
* Created `cqui_ingametext.xml`
* Added German translation `cqui_ingametext_de.xml`.

Additional fixes in `CQUI.modinfo`:
* Added "*_ja.xml" files in all sections.
* Sorted text files alphabetically.