### PR TITLE
Real Housing Fall 2017 update

### DIFF
--- a/Assets/UI/Panels/citypanel.lua
+++ b/Assets/UI/Panels/citypanel.lua
@@ -645,6 +645,7 @@ function ViewMain( data:table )
   -- CQUI get real housing from improvements value
   local selectedCityID = selectedCity:GetID();
   local CQUI_HousingFromImprovements = CQUI_HousingFromImprovementsTable[selectedCityID];
+
   Controls.HousingNum:SetText( data.Population );
   colorName = GetPercentGrowthColor( data.HousingMultiplier );
   Controls.HousingNum:SetColorByName( colorName );
@@ -1424,7 +1425,7 @@ function CQUI_UpdateSelectedCityCitizens( plotId:number )
 end
 
 -- ===========================================================================
---CQUI get real housing from improvements
+-- CQUI get real housing from improvements
 function CQUI_HousingFromImprovementsTableInsert (pCityID, CQUI_HousingFromImprovements)
   CQUI_HousingFromImprovementsTable[pCityID] = CQUI_HousingFromImprovements;
 end
@@ -1515,7 +1516,9 @@ function Initialize()
   LuaEvents.CQUI_ToggleGrowthTile.Add( CQUI_ToggleGrowthTile );
   LuaEvents.CQUI_SettingsUpdate.Add( CQUI_SettingsUpdate );
   LuaEvents.RefreshCityPanel.Add(Refresh);
-  LuaEvents.CQUI_RealHousingFromImprovementsCalculated.Add(CQUI_HousingFromImprovementsTableInsert);    --CQUI get real housing from improvements values
+  LuaEvents.CQUI_RealHousingFromImprovementsCalculated.Add(CQUI_HousingFromImprovementsTableInsert);    -- CQUI get real housing from improvements values
+  LuaEvents.CQUI_CityLostTileToCultureBomb.Add( Refresh );    -- CQUI update real housing from improvements when a city lost tile to a Culture Bomb
+  LuaEvents.CQUI_IndiaPlayerResearchedSanitation.Add( Refresh );    -- CQUI update real housing from improvements when play as India and researched Sanitation
 
   -- Truncate possible static text overflows
   TruncateStringWithTooltip(Controls.BreakdownLabel,  MAX_BEFORE_TRUNC_STATIC_LABELS, Controls.BreakdownLabel:GetText());

--- a/Assets/UI/Panels/notificationpanel.lua
+++ b/Assets/UI/Panels/notificationpanel.lua
@@ -1430,8 +1430,8 @@ function OnNotificationAdded( playerID:number, notificationID:number )
       UI.DataError("Notification added Event but not found in manager. PlayerID - " .. tostring(playerID) .. " Notification ID - " .. tostring(notificationID));
     end
 
-    if notificationID	== 577 then                   -- CQUI: Notification when a City lost tile by Culture Bomb (Index == 577)
-      LuaEvents.CQUI_CityLostTileByCultureBomb();
+    if notificationID	== 577 then                   -- CQUI: Notification when a City lost tile to a Culture Bomb (Index == 577)
+      LuaEvents.CQUI_CityLostTileToCultureBomb();
     end
   end
 end

--- a/Assets/UI/Screens/techtree.lua
+++ b/Assets/UI/Screens/techtree.lua
@@ -1172,6 +1172,13 @@ function OnResearchComplete( ePlayer:number, eTech:number)
 
         --------------------------------------------------------------------------
 
+    -- CQUI update all cities real housing when play as India and researched sanitation
+    if(PlayerConfigurations[ePlayer]:GetCivilizationTypeName() == "CIVILIZATION_INDIA") then
+      if eTech == 40 then    -- Sanitation (Index == 40)
+        LuaEvents.CQUI_IndiaPlayerResearchedSanitation();
+      end
+    end
+
   end
 end
 

--- a/Assets/UI/WorldView/citybannermanager.lua
+++ b/Assets/UI/WorldView/citybannermanager.lua
@@ -3260,12 +3260,16 @@ function CQUI_RealHousingFromImprovements(pCity)
       local kImprovementData = GameInfo.Improvements[eImprovementType].Housing;
         if kImprovementData == 1 then    -- farms, pastures etc.
           CQUI_HousingFromImprovements = CQUI_HousingFromImprovements + 1;
-        elseif kImprovementData == 2 then    -- stepwells
-          local CQUI_PlayerResearchedSanitation :boolean = Players[Game.GetLocalPlayer()]:GetTechs():HasTech(40);    -- check if a player researched Sanitation (Index == 40)
-          if not CQUI_PlayerResearchedSanitation then
+        elseif kImprovementData == 2 then    -- kampungs and stepwells
+          if eImprovementType == 26 then    -- kampungs (Index == 26)
             CQUI_HousingFromImprovements = CQUI_HousingFromImprovements + 2;
-          else
-            CQUI_HousingFromImprovements = CQUI_HousingFromImprovements + 4;
+          else    -- stepwells
+            local CQUI_PlayerResearchedSanitation :boolean = Players[Game.GetLocalPlayer()]:GetTechs():HasTech(40);    -- check if a player researched Sanitation (Index == 40)
+            if not CQUI_PlayerResearchedSanitation then
+              CQUI_HousingFromImprovements = CQUI_HousingFromImprovements + 2;
+            else
+              CQUI_HousingFromImprovements = CQUI_HousingFromImprovements + 4;
+            end
           end
         end
       end
@@ -3285,7 +3289,7 @@ function CQUI_OnCityInfoUpdated(pCityID)
 end
 
 -- ===========================================================================
-function CQUI_OnCityLostTileByCultureBomb()
+function CQUI_OnAllCitiesInfoUpdated()
   local m_pCity:table = Players[Game.GetLocalPlayer()]:GetCities();
   for i, pCity in m_pCity:Members() do
     local pCityID = pCity:GetID();
@@ -3357,7 +3361,8 @@ function Initialize()
   Events.CityWorkerChanged.Add(           OnCityWorkerChanged );
 
   LuaEvents.CQUI_CityInfoUpdated.Add( CQUI_OnCityInfoUpdated );
-  LuaEvents.CQUI_CityLostTileByCultureBomb.Add( CQUI_OnCityLostTileByCultureBomb );
+  LuaEvents.CQUI_CityLostTileToCultureBomb.Add( CQUI_OnAllCitiesInfoUpdated );
+  LuaEvents.CQUI_IndiaPlayerResearchedSanitation.Add( CQUI_OnAllCitiesInfoUpdated );
 
   LuaEvents.GameDebug_Return.Add(OnGameDebugReturn);
 

--- a/Assets/UI/WorldView/plotinfo.lua
+++ b/Assets/UI/WorldView/plotinfo.lua
@@ -503,6 +503,15 @@ function OnDistrictAddedToMap( playerID: number, districtID : number, cityID :nu
     OnMapYieldsChanged();
     -- UI.DeselectAllCities();
   end
+
+  -- CQUI update citizens and data for close cities within 4 tiles when city founded
+  -- we use it only to update real housing for a city that loses a 3rd radius tile to a city that is founded within 4 tiles
+  if playerID == Game.GetLocalPlayer() then
+    if districtType == CITY_CENTER_DISTRICT_INDEX then
+      local kCity = CityManager.GetCity(playerID, cityID);
+      CQUI_UpdateCloseCitiesCitizensWhenCityFounded(kCity);
+    end
+  end
 end
 
 function OnBuildingAddedToMap( plotX:number, plotY:number, buildingType:number, misc1, misc2, misc3 )
@@ -942,6 +951,37 @@ function CQUI_UpdateCloseCitiesCitizensWhenSwapTiles(kPlot)
   local m_pCity:table = Players[Game.GetLocalPlayer()]:GetCities();
   for i, pCity in m_pCity:Members() do
     if Map.GetPlotDistance(kPlot:GetX(), kPlot:GetY(), pCity:GetX(), pCity:GetY()) <= 3 then
+      local pCitizens   :table = pCity:GetCitizens();
+      local tParameters :table = {};
+
+      if pCitizens:IsFavoredYield(YieldTypes.CULTURE) then
+        tParameters[CityCommandTypes.PARAM_FLAGS] = 0;        -- Set favoured
+        tParameters[CityCommandTypes.PARAM_DATA0] = 1;        -- on
+      elseif pCitizens:IsDisfavoredYield(YieldTypes.CULTURE) then
+        tParameters[CityCommandTypes.PARAM_FLAGS] = 1;        -- Set Ignored
+        tParameters[CityCommandTypes.PARAM_DATA0] = 1;        -- on
+      else
+        tParameters[CityCommandTypes.PARAM_FLAGS] = 0;        -- Set favoured
+        tParameters[CityCommandTypes.PARAM_DATA0] = 0;        -- off
+      end
+
+      tParameters[CityCommandTypes.PARAM_YIELD_TYPE] = YieldTypes.CULTURE;  -- Yield type
+      CityManager.RequestCommand(pCity, CityCommandTypes.SET_FOCUS, tParameters);
+
+      local pCityID = pCity:GetID();
+      LuaEvents.CQUI_CityInfoUpdated(pCityID);
+    end
+  end
+end
+
+-- ===========================================================================
+-- CQUI update citizens and data for close cities within 4 tiles when city founded
+-- we use it only to update real housing for a city that loses a 3rd radius tile to a city that is founded within 4 tiles
+function CQUI_UpdateCloseCitiesCitizensWhenCityFounded(kCity)
+
+  local m_pCity:table = Players[Game.GetLocalPlayer()]:GetCities();
+  for i, pCity in m_pCity:Members() do
+    if Map.GetPlotDistance(kCity:GetX(), kCity:GetY(), pCity:GetX(), pCity:GetY()) == 4 then
       local pCitizens   :table = pCity:GetCitizens();
       local tParameters :table = {};
 


### PR DESCRIPTION
Added Indonesian Kampungs to real housing from improvements code. Also improved data update when a city loses a tile to a Culture Bomb or when research Sanitation when play for India. Also added a function to update data for a city that loses a 3rd radius tile to a city that is founded within 4 tiles.

Previously we updated all cities data when swapped tiles and now we do this for cities that are within 3 tiles range from a swapped tile only.