### PR TITLE
Real Housing improve, revert some changes of city data updates

### DIFF
--- a/Assets/UI/Panels/citypanel.lua
+++ b/Assets/UI/Panels/citypanel.lua
@@ -232,14 +232,12 @@ function CQUI_OnNextCity()
   local kCity:table = UI.GetHeadSelectedCity();
   UI.SelectNextCity(kCity);
   UI.PlaySound("UI_Click_Sweetener_Metal_Button_Small");
-  CQUI_UpdateSelectedCityCitizens();
 end
 
 function CQUI_OnPreviousCity()
   local kCity:table = UI.GetHeadSelectedCity();
   UI.SelectPrevCity(kCity);
   UI.PlaySound("UI_Click_Sweetener_Metal_Button_Small");
-  CQUI_UpdateSelectedCityCitizens();
 end
 
 function CQUI_OnLoadScreenClose()
@@ -1408,20 +1406,6 @@ function OnTutorial_ContextDisableItems( contextName:string, kIdsToDisable:table
       end
     end
   end
-end
-
--- ===========================================================================
-function CQUI_UpdateSelectedCityCitizens( plotId:number )
-
-  local pSelectedCity	:table = UI.GetHeadSelectedCity();
-  local kPlot			:table = Map.GetPlotByIndex(plotId);
-  local tParameters	:table = {};
-  tParameters[CityCommandTypes.PARAM_MANAGE_CITIZEN] = UI.GetInterfaceModeParameter(CityCommandTypes.PARAM_MANAGE_CITIZEN);
-  tParameters[CityCommandTypes.PARAM_X] = kPlot:GetX();
-  tParameters[CityCommandTypes.PARAM_Y] = kPlot:GetY();
-
-  local tResults :table = CityManager.RequestCommand( pSelectedCity, CityCommandTypes.MANAGE, tParameters );
-  return true;
 end
 
 -- ===========================================================================

--- a/Assets/UI/Screens/techtree.lua
+++ b/Assets/UI/Screens/techtree.lua
@@ -1173,8 +1173,8 @@ function OnResearchComplete( ePlayer:number, eTech:number)
         --------------------------------------------------------------------------
 
     -- CQUI update all cities real housing when play as India and researched sanitation
-    if(PlayerConfigurations[ePlayer]:GetCivilizationTypeName() == "CIVILIZATION_INDIA") then
-      if eTech == 40 then    -- Sanitation (Index == 40)
+    if eTech == 40 then    -- Sanitation (Index == 40)
+      if(PlayerConfigurations[ePlayer]:GetCivilizationTypeName() == "CIVILIZATION_INDIA") then
         LuaEvents.CQUI_IndiaPlayerResearchedSanitation();
       end
     end

--- a/Assets/UI/WorldView/citybannermanager.lua
+++ b/Assets/UI/WorldView/citybannermanager.lua
@@ -1436,7 +1436,6 @@ function OnCityBannerClick( playerID:number, cityID:number )
     end
 
   end
-  CQUI_UpdateSelectedCityCitizens();
 end
 
 -- ===========================================================================
@@ -3211,36 +3210,6 @@ function OnInterfaceModeChanged( oldMode:number, newMode:number )
       end
     end
   end
-end
-
--- ===========================================================================
-function CQUI_UpdateSelectedCityCitizens( plotId:number )
-
-  local pSelectedCity	:table = UI.GetHeadSelectedCity();
-  local kPlot			:table = Map.GetPlotByIndex(plotId);
-  local tParameters	:table = {};
-  tParameters[CityCommandTypes.PARAM_MANAGE_CITIZEN] = UI.GetInterfaceModeParameter(CityCommandTypes.PARAM_MANAGE_CITIZEN);
-  tParameters[CityCommandTypes.PARAM_X] = kPlot:GetX();
-  tParameters[CityCommandTypes.PARAM_Y] = kPlot:GetY();
-
-  local tResults :table = CityManager.RequestCommand( pSelectedCity, CityCommandTypes.MANAGE, tParameters );
-  return true;
-end
-
--- ===========================================================================
--- CQUI recenter camera on city when right click on citybanner
-function OnCityBannerRightClick( playerID:number, cityID:number )
-  local pPlayer = Players[playerID];
-  if (pPlayer == nil) then
-    return;
-  end
-
-  local pCity = pPlayer:GetCities():FindID(cityID);
-  if (pCity == nil) then
-    return;
-  end
-
-  UI.LookAtPlot( pCity:GetX(), pCity:GetY() );
 end
 
 -- ===========================================================================

--- a/Assets/UI/WorldView/plotinfo.lua
+++ b/Assets/UI/WorldView/plotinfo.lua
@@ -78,7 +78,9 @@ function OnClickSwapTile( plotId:number )
 
   local tResults :table = CityManager.RequestCommand( pSelectedCity, CityCommandTypes.SWAP_TILE_OWNER, tParameters );
 
-  CQUI_UpdateCloseCitiesCitizensWhenSwapTiles(kPlot);    -- CQUI update citizens and data for close cities within 3 tiles when swap tiles
+  CQUI_UpdateCitiesCitizensWhenSwapTiles(pSelectedCity);    -- CQUI update citizens and data for a city that is a new tile owner
+  local pCity = Cities.GetPlotPurchaseCity(kPlot);    -- CQUI a city that was a previous tile owner
+  CQUI_UpdateCitiesCitizensWhenSwapTiles(pCity);    -- CQUI update citizens and data for a city that was a previous tile owner
   return true;
 end
 
@@ -502,18 +504,16 @@ function OnDistrictAddedToMap( playerID: number, districtID : number, cityID :nu
     OnPlotYieldChanged(districtX, districtY);
     OnMapYieldsChanged();
     -- UI.DeselectAllCities();
-  end
 
-  -- CQUI update citizens and data for close cities within 4 tiles when city founded
-  -- we use it only to update real housing for a city that loses a 3rd radius tile to a city that is founded within 4 tiles
-  if playerID == Game.GetLocalPlayer() then
-    if districtType == CITY_CENTER_DISTRICT_INDEX then
-      local kCity = CityManager.GetCity(playerID, cityID);
-      CQUI_UpdateCloseCitiesCitizensWhenCityFounded(kCity);
-    end
+    -- CQUI update citizens and data for close cities within 4 tiles when city founded
+    -- we use it only to update real housing for a city that loses a 3rd radius tile to a city that is founded within 4 tiles
+  elseif playerID == Game.GetLocalPlayer() then
+    local kCity = CityManager.GetCity(playerID, cityID);
+    CQUI_UpdateCloseCitiesCitizensWhenCityFounded(kCity);
   end
 end
 
+-- ===========================================================================
 function OnBuildingAddedToMap( plotX:number, plotY:number, buildingType:number, misc1, misc2, misc3 )
 end
 
@@ -945,33 +945,28 @@ function OnInputHandler( pInputStruct:table )
 end
 
 -- ===========================================================================
--- CQUI update citizens and data for close cities within 3 tiles when swap tiles
-function CQUI_UpdateCloseCitiesCitizensWhenSwapTiles(kPlot)
+-- CQUI update citizens and data for both cities when swap tiles
+function CQUI_UpdateCitiesCitizensWhenSwapTiles(pCity)
 
-  local m_pCity:table = Players[Game.GetLocalPlayer()]:GetCities();
-  for i, pCity in m_pCity:Members() do
-    if Map.GetPlotDistance(kPlot:GetX(), kPlot:GetY(), pCity:GetX(), pCity:GetY()) <= 3 then
-      local pCitizens   :table = pCity:GetCitizens();
-      local tParameters :table = {};
+  local pCitizens   :table = pCity:GetCitizens();
+  local tParameters :table = {};
 
-      if pCitizens:IsFavoredYield(YieldTypes.CULTURE) then
-        tParameters[CityCommandTypes.PARAM_FLAGS] = 0;        -- Set favoured
-        tParameters[CityCommandTypes.PARAM_DATA0] = 1;        -- on
-      elseif pCitizens:IsDisfavoredYield(YieldTypes.CULTURE) then
-        tParameters[CityCommandTypes.PARAM_FLAGS] = 1;        -- Set Ignored
-        tParameters[CityCommandTypes.PARAM_DATA0] = 1;        -- on
-      else
-        tParameters[CityCommandTypes.PARAM_FLAGS] = 0;        -- Set favoured
-        tParameters[CityCommandTypes.PARAM_DATA0] = 0;        -- off
-      end
-
-      tParameters[CityCommandTypes.PARAM_YIELD_TYPE] = YieldTypes.CULTURE;  -- Yield type
-      CityManager.RequestCommand(pCity, CityCommandTypes.SET_FOCUS, tParameters);
-
-      local pCityID = pCity:GetID();
-      LuaEvents.CQUI_CityInfoUpdated(pCityID);
-    end
+  if pCitizens:IsFavoredYield(YieldTypes.CULTURE) then
+    tParameters[CityCommandTypes.PARAM_FLAGS] = 0;        -- Set favoured
+    tParameters[CityCommandTypes.PARAM_DATA0] = 1;        -- on
+  elseif pCitizens:IsDisfavoredYield(YieldTypes.CULTURE) then
+    tParameters[CityCommandTypes.PARAM_FLAGS] = 1;        -- Set Ignored
+    tParameters[CityCommandTypes.PARAM_DATA0] = 1;        -- on
+  else
+    tParameters[CityCommandTypes.PARAM_FLAGS] = 0;        -- Set favoured
+    tParameters[CityCommandTypes.PARAM_DATA0] = 0;        -- off
   end
+
+  tParameters[CityCommandTypes.PARAM_YIELD_TYPE] = YieldTypes.CULTURE;  -- Yield type
+  CityManager.RequestCommand(pCity, CityCommandTypes.SET_FOCUS, tParameters);
+
+  local pCityID = pCity:GetID();
+  LuaEvents.CQUI_CityInfoUpdated(pCityID);
 end
 
 -- ===========================================================================

--- a/Assets/UI/worldinput.lua
+++ b/Assets/UI/worldinput.lua
@@ -3547,30 +3547,14 @@ function OnInputActionTriggered( actionId )
   elseif actionId == m_actionHotkeyPrevCity then
     LuaEvents.CQUI_GoPrevCity();
     UI.PlaySound("Play_UI_Click");
-    CQUI_UpdateSelectedCityCitizens();
   elseif actionId == m_actionHotkeyNextCity then
     LuaEvents.CQUI_GoNextCity();
     UI.PlaySound("Play_UI_Click");
-    CQUI_UpdateSelectedCityCitizens();
   elseif actionId == m_actionHotkeyOnlinePause then
     if GameConfiguration.IsNetworkMultiplayer() then
       TogglePause();
     end
   end
-end
-
--- ===========================================================================
-function CQUI_UpdateSelectedCityCitizens( plotId:number )
-
-  local pSelectedCity	:table = UI.GetHeadSelectedCity();
-  local kPlot			:table = Map.GetPlotByIndex(plotId);
-  local tParameters	:table = {};
-  tParameters[CityCommandTypes.PARAM_MANAGE_CITIZEN] = UI.GetInterfaceModeParameter(CityCommandTypes.PARAM_MANAGE_CITIZEN);
-  tParameters[CityCommandTypes.PARAM_X] = kPlot:GetX();
-  tParameters[CityCommandTypes.PARAM_Y] = kPlot:GetY();
-
-  local tResults :table = CityManager.RequestCommand( pSelectedCity, CityCommandTypes.MANAGE, tParameters );
-  return true;
 end
 
 -- ===========================================================================


### PR DESCRIPTION
With the last real housing update we started to update data for close cities within 3 tiles when swap tiles. Now we update data for 2 cities only. Don't know why I didn't find how to do so from the beginning. Also made minor changes when researched Sanitation for India and when a city founded within 4 tiles from another city.

'CQUI_UpdateSelectedCityCitizens' function was added to update cities data when swap or improve tiles. Now we update it without this function so we don't need it. It also freezes the camera every time when choose another city from a cityview. So here we remove it.
'OnCityBannerRightClick' function was added to recenter camera on city. It makes harder to move units to plots that are adjacent to city centers sometimes. We have a Middle Click for recentering camera anyway so here we remove this function also.