### PR TITLE
Accidental Tile Purchases Fix

### DIFF
--- a/Assets/UI/WorldView/plotinfo.lua
+++ b/Assets/UI/WorldView/plotinfo.lua
@@ -201,7 +201,7 @@ function ShowPurchases()
           else
             pInstance.PurchaseButton:GetTextControl():SetColorByName("ResGoldLabelCS");
           end
-          pInstance.PurchaseButton:RegisterCallback( Mouse.eLClick, function() OnClickPurchasePlot( index ); end );
+          pInstance.PurchaseButton:RegisterCallback( Mouse.eRClick, function() OnClickPurchasePlot( index ); end );
           pInstance.PurchaseAnim:SetColor( (goldCost > playerGold ) and 0xbb808080 or 0xffffffff ) ;
           pInstance.PurchaseAnim:RegisterEndCallback( OnSpinningCoinAnimDone );
           if (goldCost > playerGold ) then


### PR DESCRIPTION
A simple fix for Accidental Tile Purchases  by changing the Left click action to Right click to stop Accidental Tile Purchases while dragging on screen