### PR TITLE
Alternative fix for to the accidental tile purchases

### DIFF
--- a/Assets/UI/WorldView/plotinfo.lua
+++ b/Assets/UI/WorldView/plotinfo.lua
@@ -44,6 +44,8 @@ local CQUI_WorkIconAlpha = .60;
 local CQUI_SmartWorkIcon: boolean = true;
 local CQUI_SmartWorkIconSize: number = 64;
 local CQUI_SmartWorkIconAlpha = .45;
+local CQUI_isMouseDragging = false;
+local CQUI_hasMouseDragged = false;
 
 function CQUI_OnSettingsUpdate()
   CQUI_WorkIconSize = GameConfiguration.GetValue("CQUI_WorkIconSize");
@@ -86,6 +88,11 @@ end
 
 -- ===========================================================================
 function OnClickPurchasePlot( plotId:number )
+
+  -- AZURENCY : if we're dragging, don't purchase
+  if CQUI_isMouseDragging and CQUI_hasMouseDragged then
+    return
+  end
 
   local isUsingDistrictPlacementFilter :boolean = (UI.GetInterfaceMode() == InterfaceModeTypes.DISTRICT_PLACEMENT);
   local isUsingBuildingPlacementFilter :boolean = (UI.GetInterfaceMode() == InterfaceModeTypes.BUILDING_PLACEMENT);
@@ -938,9 +945,27 @@ function KeyHandler( key:number )
   end
   return false;
 end
+
 function OnInputHandler( pInputStruct:table )
   local uiMsg = pInputStruct:GetMessageType();
   if (uiMsg == KeyEvents.KeyUp) then return KeyHandler( pInputStruct:GetKey() ); end;
+
+  -- AZURENCY : added drag awareness to handle the clic/drag on purchase button (from minimap.lua)
+  -- Enable drag on LMB down
+  if uiMsg == MouseEvents.LButtonDown then
+    CQUI_isMouseDragging = true; -- Potential drag is in process
+    CQUI_hasMouseDragged = false; -- There has been no actual dragging yet
+    return false;
+  -- Disable drag on LMB up (but only if mouse was previously dragging)
+  elseif uiMsg == MouseEvents.LButtonUp and CQUI_isMouseDragging then
+    CQUI_isMouseDragging = false;
+    return false;
+  -- If the mouse move and is dragging, it has dragged
+  elseif uiMsg == MouseEvents.MouseMove and CQUI_isMouseDragging then
+    CQUI_hasMouseDragged = true;
+    return false;
+  end
+
   return false;
 end
 

--- a/Assets/UI/WorldView/plotinfo.xml
+++ b/Assets/UI/WorldView/plotinfo.xml
@@ -5,7 +5,7 @@
 
   <Instance         Name="InfoInstance">
     <WorldAnchor    ID="Anchor"                                           Size="2,2" >
-      <GridButton       ID="PurchaseButton" Anchor="C,T"  Offset="0,-40" Size="51,30" Hidden="1" Style="PurchaseTileButton">
+      <GridButton       ID="PurchaseButton" Anchor="C,T"  Offset="0,-40" Size="51,30" Hidden="1" Style="PurchaseTileButton" ConsumeMouseButton="0">
         <FlipAnim   ID="PurchaseAnim" Size="32,32" Columns="8"  FrameCount="40" Speed="25" Texture="CityPanel_PurchaseTileAnim" Cycle="Once" Stopped="1" Anchor="L,C" Offset="0,0"/>
       <Label      ID="Amount" Anchor="R,C"  Offset="4,0" Style="CityPanelNumLarge" Align="Right"/>
       </GridButton>


### PR DESCRIPTION
As discussed in #201 only buy a tile if there's no drag.
I just register the drag event with mouse down, mouse up and mouse move (like in `minimappanel.lua` for instance) and then check that in `OnClickPurchasePlot`

It needs to be tested.