### PR TITLE
Adds gold balance and yield to leader icon tooltip

### DIFF
--- a/Assets/UI/diplomacyribbon.lua
+++ b/Assets/UI/diplomacyribbon.lua
@@ -227,9 +227,15 @@ function GetExtendedTooltip(playerID:number)
   for i,city in cities:Members() do
     numCities = numCities + 1;
   end
+  --ARISTOS: Add gold to tooltip
+  local playerTreasury:table	= Players[playerID]:GetTreasury();
+  local goldBalance	:number = math.floor(playerTreasury:GetGoldBalance());
+  local goldYield	:number = math.floor((playerTreasury:GetGoldYield() - playerTreasury:GetTotalMaintenance()));
+  
   local civData:string = "[NEWLINE]"..Locale.Lookup("LOC_DIPLOMACY_INTEL_GOVERNMENT").." "..govType
     .."[NEWLINE]"..Locale.Lookup("LOC_PEDIA_CONCEPTS_PAGEGROUP_CITIES_NAME").. ": "..numCities
     .."[NEWLINE][ICON_Capital] "..Locale.Lookup("LOC_WORLD_RANKINGS_OVERVIEW_DOMINATION_SCORE", Players[playerID]:GetScore())
+	.."[NEWLINE][ICON_Gold] "..goldBalance.." / " .. (goldYield>0 and "+" or "") .. (goldYield>0 and goldYield or "?")
     .."[NEWLINE]"..Locale.Lookup("LOC_WORLD_RANKINGS_OVERVIEW_SCIENCE_SCIENCE_RATE", Round(Players[playerID]:GetTechs():GetScienceYield(),1))
     .."[NEWLINE][ICON_Science] "..Locale.Lookup("LOC_WORLD_RANKINGS_OVERVIEW_SCIENCE_NUM_TECHS", Players[playerID]:GetStats():GetNumTechsResearched())
     .."[NEWLINE]"..Locale.Lookup("LOC_WORLD_RANKINGS_OVERVIEW_CULTURE_CULTURE_RATE", Round(Players[playerID]:GetCulture():GetCultureYield(),1))


### PR DESCRIPTION
This patch adds the gold balance and yield to each leader icon tooltip in the diplo ribbon. Vanilla civ 6 does not display information when the yield of a given leader is negative (inside the deal screen), so we follow the same pattern to preserve the non-gameplay-altering nature of CQUI. When yield is negative, tooltip displays a ? symbol.