### PR TITLE
Espionage patch. Fixes #234.

### DIFF
--- a/Integrations/BES/UI/PartialScreens/espionageoverview.lua
+++ b/Integrations/BES/UI/PartialScreens/espionageoverview.lua
@@ -424,7 +424,7 @@ function AddDistrictIcon(stackControl:table, city:table, districtType:string)
   local hasDistrict:boolean = false;
   local cityDistricts:table = city:GetDistricts();
   for i, district in cityDistricts:Members() do
-    if district:IsComplete() then
+    if district:IsComplete() and not district:IsPillaged() then
       local districtInfo:table = GameInfo.Districts[district:GetType()];
       if districtInfo.DistrictType == districtType then
         hasDistrict = true;

--- a/Integrations/BES/UI/PartialScreens/espionageoverview.lua
+++ b/Integrations/BES/UI/PartialScreens/espionageoverview.lua
@@ -421,20 +421,21 @@ function AddDistrictIcon(stackControl:table, city:table, districtType:string)
   local toolTipString:string = "";
 
   -- Check if we have this district
-  local hasDistrict:boolean = false;
-  local cityDistricts:table = city:GetDistricts();
-  for i, district in cityDistricts:Members() do
-    if district:IsComplete() and not district:IsPillaged() then
-      local districtInfo:table = GameInfo.Districts[district:GetType()];
-      if districtInfo.DistrictType == districtType then
-        hasDistrict = true;
-        toolTipString = Locale.Lookup(districtInfo.Name);
-      end
-    end
-  end
+  -- local hasDistrict:boolean = false;
+  -- local cityDistricts:table = city:GetDistricts();
+  -- for i, district in cityDistricts:Members() do
+    -- if district:IsComplete() and not district:IsPillaged() then
+      -- local districtInfo:table = GameInfo.Districts[district:GetType()];
+      -- if districtInfo.DistrictType == districtType then
+        -- hasDistrict = true;
+        -- toolTipString = Locale.Lookup(districtInfo.Name);
+      -- end
+    -- end
+  -- end
 
   -- We're manipulating the alpha to hide each element so they maintain their stack positions
-  if hasDistrict then
+  if hasDistrict(city, districtType) then
+	toolTipString = Locale.Lookup(GameInfo.Districts[districtType].Name);
     districtInstance.DistrictIcon:SetAlpha(1.0);
   else
     districtInstance.DistrictIcon:SetAlpha(0.0);

--- a/Integrations/BES/UI/espionagesupport.lua
+++ b/Integrations/BES/UI/espionagesupport.lua
@@ -129,7 +129,7 @@ function hasDistrict(city:table, districtType:string)
   local hasDistrict:boolean = false;
   local cityDistricts:table = city:GetDistricts();
   for i, district in cityDistricts:Members() do
-    if district:IsComplete() then
+    if district:IsComplete() and not district:IsPillaged() then
       --gets the district type of the currently selected district
       local districtInfo:table = GameInfo.Districts[district:GetType()];
       local currentDistrictType = districtInfo.DistrictType


### PR DESCRIPTION
Fixes #234. Shows only districts that are valid targets.