### PR TITLE
Fix the automatic unit cycling

### DIFF
--- a/Assets/UI/actionpanel.lua
+++ b/Assets/UI/actionpanel.lua
@@ -687,6 +687,8 @@ function SelectUnit(unit)
   UI.DeselectAllUnits();
   UI.DeselectAllCities();
   UI.SelectUnit( unit );
+  -- Azurency : also look at the unit when selecting it.
+  UI.LookAtPlot(unit:GetX(), unit:GetY())
 end
 
 

--- a/Assets/UI/actionpanel.lua
+++ b/Assets/UI/actionpanel.lua
@@ -688,7 +688,7 @@ function SelectUnit(unit)
   UI.DeselectAllCities();
   UI.SelectUnit( unit );
   -- Azurency : also look at the unit when selecting it.
-  UI.LookAtPlot(unit:GetX(), unit:GetY())
+  UI.LookAtPlot(unit:GetX(), unit:GetY());
 end
 
 

--- a/Assets/UI/worldinput.lua
+++ b/Assets/UI/worldinput.lua
@@ -3098,10 +3098,28 @@ function OnCycleUnitSelectionRequest()
   --end
 
   if(UI.GetInterfaceMode() ~= InterfaceModeTypes.NATURAL_WONDER or m_isMouseButtonRDown) then
-    -- Auto-advance selection to the next unit.
-    if not UI.SelectNextReadyUnit() then
-      UI.DeselectAllUnits();
+
+    -- AZURENCY : OnCycleUnitSelectionRequest is called by UI.SetCycleAdvanceTimer() 
+    -- in SelectedUnit.lua causing a conflict with the auto-cyling of unit 
+    -- (not the same given by UI.SelectNextReadyUnit() and player:GetUnits():GetFirstReadyUnit())
+    local pPlayer :table = Players[Game.GetLocalPlayer()];
+    if pPlayer ~= nil then
+      if pPlayer:IsTurnActive() then
+        local unit:table = pPlayer:GetUnits():GetFirstReadyUnit();
+        -- AZURENCY : we also check if there is not already a unit selected, 
+        -- bacause UI.SetCycleAdvanceTimer() is always called after deselecting a unit
+        if unit ~= nil and not UI.GetHeadSelectedUnit() then
+          UI.DeselectAllUnits();
+          UI.DeselectAllCities();
+          UI.SelectUnit(unit);
+          UI.LookAtPlot(unit:GetX(), unit:GetY())
+        end
+      end
     end
+    -- Auto-advance selection to the next unit.
+    -- if not UI.SelectNextReadyUnit() then
+    --   UI.DeselectAllUnits();
+    -- end
   end
 end
 

--- a/Assets/UI/worldinput.lua
+++ b/Assets/UI/worldinput.lua
@@ -3112,7 +3112,7 @@ function OnCycleUnitSelectionRequest()
           UI.DeselectAllUnits();
           UI.DeselectAllCities();
           UI.SelectUnit(unit);
-          UI.LookAtPlot(unit:GetX(), unit:GetY())
+          UI.LookAtPlot(unit:GetX(), unit:GetY());
         end
       end
     end


### PR DESCRIPTION
Should fix the annoying behavior explained in #239.
The problem was that SelectedUnit.lua called `UI.SetCycleAdvanceTimer();` and that ActionPanel.lua used `pPlayer:GetUnits():GetFirstReadyUnit();` but they do not return the same unit and `UI.SetCycleAdvanceTimer();` have a timer so it selected the other unit a few second later. 

Now `UI.SetCycleAdvanceTimer();` will use the same method as in ActionPanel to select a unit (if none is  already selected).

Need some testing though, tell me if it's working better now.