### PR TITLE
Fixes #29 - Adds a CQUI setting to disable wonder movies and/or audio

### DIFF
--- a/Assets/Text/cqui_text_settings.xml
+++ b/Assets/Text/cqui_text_settings.xml
@@ -186,6 +186,18 @@
     <Row Tag="LOC_CQUI_POPUPS_TECHAUDIO_TOOLTIP" Language="en_US">
       <Text>Toggles the popup audio that plays whenever a new tech or civic is achieved. Is fully independent of the visual component and can play even when there is no visible popup.</Text>
     </Row>
+    <Row Tag="LOC_CQUI_POPUPS_WONDERBUILTVISUAL" Language="en_US">
+      <Text>Wonder popup movie</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_POPUPS_WONDERBUILTVISUAL_TOOLTIP" Language="en_US">
+      <Text>Toggles the popup movie that appears whenever a wonder is completed</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_POPUPS_WONDERBUILTAUDIO" Language="en_US">
+      <Text>Wonder popup audio</Text>
+    </Row>
+    <Row Tag="LOC_CQUI_POPUPS_WONDERBUILTAUDIO_TOOLTIP" Language="en_US">
+      <Text>Toggles the popup audio that plays whenever a wonder is completed. Is fully independent of the visual component and can play even when there is no visible popup.</Text>
+    </Row>
     <Row Tag="LOC_CQUI_SETTINGS_REMINDER" Language="en_US">
       <Text>Remember: CQUI settings are attached to individual saves![NEWLINE]If you'd like to change a setting by default, please read the info[NEWLINE]in cqui_settings.sql file within the [MOD INSTALL DIRECTORY]/CQUI/Assets directory</Text>
     </Row>

--- a/Assets/UI/Popups/wonderbuiltpopup.lua
+++ b/Assets/UI/Popups/wonderbuiltpopup.lua
@@ -1,0 +1,179 @@
+-- WonderBuiltPopup
+-- Triggered from game event Event.WonderCompleted
+
+--	***************************************************************************
+--	MEMBERS
+--	***************************************************************************
+local ms_eventID = 0;
+
+-- Remolten: CQUI Members (access CQUI settings)
+local CQUI_wonderBuiltVisual = true;
+local CQUI_wonderBuiltAudio = true;
+
+function CQUI_OnSettingsUpdate()
+  CQUI_wonderBuiltVisual = GameConfiguration.GetValue("CQUI_WonderBuiltPopupVisual");
+  CQUI_wonderBuiltAudio = GameConfiguration.GetValue("CQUI_WonderBuiltPopupAudio");
+end
+
+LuaEvents.CQUI_SettingsUpdate.Add( CQUI_OnSettingsUpdate );
+LuaEvents.CQUI_SettingsInitialized.Add( CQUI_OnSettingsUpdate );
+-- Remolten: End CQUI Members
+
+function OnWonderCompleted(locX, locY, buildingIndex, playerIndex, iPercentComplete)
+
+	local localPlayer = Game.GetLocalPlayer();
+	if (localPlayer == PlayerTypes.NONE) then
+		return;	-- Nobody there to click on it, just exit.
+	end
+
+	-- No wonder popup if it is not YOU
+	if (localPlayer ~= playerIndex ) then
+		return;	
+	end
+
+	-- No wonder popups in multiplayer games.
+	if(GameConfiguration.IsAnyMultiplayer()) then
+		return;
+	end
+    
+	if (GameInfo.Buildings[buildingIndex].RequiresPlacement and iPercentComplete == 100) then
+		local currentBuildingType = GameInfo.Buildings[buildingIndex].BuildingType;
+		if currentBuildingType ~= nil then
+            -- Remolten: Begin CQUI changes (reordered in front of visual code)
+			if(GameInfo.Buildings[buildingIndex].QuoteAudio ~= nil and CQUI_wonderBuiltAudio) then
+            -- Remolten: End CQUI changes
+				UI.PlaySound(GameInfo.Buildings[buildingIndex].QuoteAudio);
+			end
+            -- Remolten: Begin CQUI changes (just added this if statement and put visual code inside of it)
+            if CQUI_wonderBuiltVisual then
+            -- Remolten: End CQUI changes
+                Controls.WonderName:SetText(Locale.ToUpper(Locale.Lookup(GameInfo.Buildings[buildingIndex].Name)));
+                Controls.WonderIcon:SetIcon("ICON_"..currentBuildingType);
+                Controls.WonderIcon:SetToolTipString(Locale.Lookup(GameInfo.Buildings[buildingIndex].Description));
+                if(Locale.Lookup(GameInfo.Buildings[buildingIndex].Quote) ~= nil) then
+                    Controls.WonderQuote:SetText(Locale.Lookup(GameInfo.Buildings[buildingIndex].Quote));
+                else
+                    UI.DataError("The field 'Quote' has not been initialized for "..GameInfo.Buildings[buildingIndex].BuildingType);
+                end
+
+                AutoSizeControls();
+
+                if UI.IsInMarketingMode() then
+                    ContextPtr:SetHide( true );
+                    Controls.ForceAutoCloseMarketingMode:SetToBeginning();
+                    Controls.ForceAutoCloseMarketingMode:Play();
+                    Controls.ForceAutoCloseMarketingMode:RegisterEndCallback( OnClose );
+                else
+                    ContextPtr:SetHide( false );
+                end
+
+                UI.LookAtPlot(locX, locY);
+
+                LuaEvents.WonderRevealPopup_Shown();	-- Signal other systems (e.g., bulk hide UI)
+
+                ms_eventID = ReferenceCurrentGameCoreEvent();
+                UIManager:QueuePopup( ContextPtr, PopupPriority.Current);
+                Controls.ReplayButton:SetEnabled(UI.GetWorldRenderView() == WorldRenderView.VIEW_3D);
+                Controls.ReplayButton:SetHide(not UI.IsWorldRenderViewAvailable(WorldRenderView.VIEW_3D));
+            end
+		end
+	end
+end
+
+function AutoSizeControls()
+	Controls.WonderQuote:ReprocessAnchoring();
+	Controls.WonderQuoteContainer:ReprocessAnchoring();
+	Controls.WonderName:ReprocessAnchoring();
+	Controls.WonderNameContainer:ReprocessAnchoring();
+	Controls.RibbonBox:ReprocessAnchoring();
+	Controls.RibbonDropShadow:ReprocessAnchoring();
+	Controls.QuoteContainer:ReprocessAnchoring();
+end
+
+function Resize()
+	local screenX, screenY:number = UIManager:GetScreenSizeVal()
+
+	Controls.GradientL:SetSizeY(screenY);
+	Controls.GradientR:SetSizeY(screenY);
+	Controls.GradientT:SetSizeX(screenX);
+	Controls.GradientB:SetSizeX(screenX);
+	Controls.GradientB2:SetSizeX(screenX);
+	Controls.HeaderDropshadow:SetSizeX(screenX);
+	Controls.HeaderGrid:SetSizeX(screenX);
+
+	Controls.VignetteRB:ReprocessAnchoring();
+	Controls.VignetteRT:ReprocessAnchoring(); 
+	Controls.VignetteLT:ReprocessAnchoring();
+	Controls.VignetteLB:ReprocessAnchoring();
+	Controls.GradientL:ReprocessAnchoring();
+	Controls.GradientR:ReprocessAnchoring();
+	Controls.GradientT:ReprocessAnchoring();
+	Controls.GradientB:ReprocessAnchoring();
+	Controls.GradientB2:ReprocessAnchoring();
+	Controls.WonderCompletedHeader:ReprocessAnchoring();
+	Controls.Close:ReprocessAnchoring();
+
+	AutoSizeControls();
+end
+
+function Close()
+	LuaEvents.WonderRevealPopup_Closed();	-- Signal other systems (e.g., bulk show UI)
+	-- Release our hold on the event
+	ReleaseGameCoreEvent( ms_eventID );
+	ms_eventID = 0;
+	UIManager:DequeuePopup( ContextPtr );
+    UI.PlaySound("Stop_Wonder_Tracks");
+end
+
+function RestartMovie()
+    -- stop the music before beginning another go-round
+    UI.PlaySound("Stop_Wonder_Tracks");
+	Events.RestartWonderMovie();
+end
+
+function OnClose()
+	Close();
+end
+
+function OnUpdateUI( type:number, tag:string, iData1:number, iData2:number, strData1:string )   
+  if type == SystemUpdateUI.ScreenResize then
+    Resize();
+  end
+end
+
+
+-- ===========================================================================
+--	Input
+--	UI Event Handler
+-- ===========================================================================
+function KeyHandler( key:number )
+    if key == Keys.VK_ESCAPE then
+		Close();
+		return true;
+    end
+    return false;
+end
+
+function OnInputHandler( pInputStruct:table )
+	local uiMsg = pInputStruct:GetMessageType();
+	if (uiMsg == KeyEvents.KeyUp) then return KeyHandler( pInputStruct:GetKey() ); end;
+	return false;
+end
+
+function OnWorldRenderViewChanged()
+	Controls.ReplayButton:SetEnabled(UI.GetWorldRenderView() == WorldRenderView.VIEW_3D);
+end
+
+function Initialize()	
+	if(not GameConfiguration.IsAnyMultiplayer()) then
+		ContextPtr:SetInputHandler( OnInputHandler, true );
+		Controls.Close:RegisterCallback(Mouse.eLClick, OnClose);
+		Controls.ReplayButton:RegisterCallback(Mouse.eLClick, RestartMovie);
+		Controls.ReplayButton:SetToolTipString(Locale.Lookup("LOC_UI_ENDGAME_REPLAY_MOVIE"));
+		Events.WonderCompleted.Add( OnWonderCompleted );	
+		Events.WorldRenderViewChanged.Add( OnWorldRenderViewChanged );
+		Events.SystemUpdateUI.Add( OnUpdateUI );
+	end
+end
+Initialize();
+

--- a/Assets/cqui_settings.sql
+++ b/Assets/cqui_settings.sql
@@ -53,6 +53,8 @@ INSERT OR REPLACE INTO CQUI_Settings -- Don't touch this line!
       ("CQUI_SmartWorkIcon", 1), -- Applies a different size/transparency to citizen icons if they're currently being worked
       ("CQUI_TechPopupVisual", 0), -- Popups will be displayed when you discover a new tech or civic (this is the normal behavior for the unmoded game)
       ("CQUI_TechPopupAudio", 1), -- Play the voiceovers when you discover a new tech or civic (this is the normal behavior for the unmoded game)
+      ("CQUI_WonderBuiltPopupVisual", 1), -- Wonder movies will be displayed when you complete a wonder (this is the normal behavior for the unmoded game)
+      ("CQUI_WonderBuiltPopupAudio", 1), -- Wonder quote audio will be played when you complete a wonder (this is the normal behavior for the unmoded game)
       ("CQUI_ToggleYieldsOnLoad", 1), -- Toggles yields immediately on load
       ('CQUI_ShowCitizenIconsOnCityHover', 0), -- Shows citizen icons when hovering over city banner
       ('CQUI_ShowCityManageAreaOnCityHover', 1), -- Shows citizen management area when hovering over city banner

--- a/Assets/cqui_settingselement.lua
+++ b/Assets/cqui_settingselement.lua
@@ -324,6 +324,8 @@ function Initialize()
   PopulateCheckBox(Controls.BlockOnCityAttackCheckbox, "CQUI_BlockOnCityAttack", Locale.Lookup("LOC_CQUI_CITYVIEW_BLOCKONCITYATTACK_TOOLTIP"));
   PopulateCheckBox(Controls.TechVisualCheckbox, "CQUI_TechPopupVisual", Locale.Lookup("LOC_CQUI_POPUPS_TECHVISUAL_TOOLTIP"));
   PopulateCheckBox(Controls.TechAudioCheckbox, "CQUI_TechPopupAudio", Locale.Lookup("LOC_CQUI_POPUPS_TECHAUDIO_TOOLTIP"));
+  PopulateCheckBox(Controls.WonderBuiltVisualCheckbox, "CQUI_WonderBuiltPopupVisual", Locale.Lookup("LOC_CQUI_POPUPS_WONDERBUILTVISUAL_TOOLTIP"));
+  PopulateCheckBox(Controls.WonderBuiltAudioCheckbox, "CQUI_WonderBuiltPopupAudio", Locale.Lookup("LOC_CQUI_POPUPS_WONDERBUILTAUDIO_TOOLTIP"));
   PopulateCheckBox(Controls.TrimGossipCheckbox, "CQUI_TrimGossip", Locale.Lookup("LOC_CQUI_GOSSIP_TRIMMESSAGE_TOOLTIP"));
 
   -- Lenses

--- a/Assets/cqui_settingselement.xml
+++ b/Assets/cqui_settingselement.xml
@@ -64,6 +64,12 @@
           <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
             <GridButton ID="AlwaysOpenTechTreesCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_POPUPS_ALWAYSOPENTECHTREES" />
           </Stack>
+          <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
+            <GridButton ID="WonderBuiltVisualCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_POPUPS_WONDERBUILTVISUAL" />
+          </Stack>
+          <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
+            <GridButton ID="WonderBuiltAudioCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_POPUPS_WONDERBUILTAUDIO" />
+          </Stack>
         </Stack>
       </Container>
       <Container ID="CityviewOptions" Size="parent,parent" Hidden="1">

--- a/CQUI.modinfo
+++ b/CQUI.modinfo
@@ -129,6 +129,7 @@
     <File>Assets/UI/Popups/policyreminderpopup.lua</File>
     <File>Assets/UI/Popups/policyreminderpopup.xml</File>
     <File>Assets/UI/Popups/techciviccompletedpopup.lua</File>
+    <File>Assets/UI/Popups/wonderbuiltpopup.lua</File>
     <File>Assets/UI/Screens/civicstree.lua</File>
     <File>Assets/UI/Screens/governmentscreen.lua</File>
     <File>Assets/UI/Screens/governmentscreen.xml</File>
@@ -270,6 +271,7 @@
         <File>Assets/UI/Popups/mappinpopup.lua</File>
         <File>Assets/UI/Popups/mappinpopup.xml</File>
         <File>Assets/UI/Popups/techciviccompletedpopup.lua</File>
+        <File>Assets/UI/Popups/wonderbuiltpopup.lua</File>
         <File>Assets/UI/Screens/techtree.lua</File>
         <File>Assets/UI/Screens/civicstree.lua</File>
         <File>Assets/UI/Screens/governmentscreen.lua</File>


### PR DESCRIPTION
Fixes #29.

I tested this change on a Mac, so I will need a Windows user to confirm that this is working on Windows as well.

It's also possible that the version of `WonderBuiltPopup.lua` that I imported from my machine is outdated. I would appreciate if a Windows user could validate that this file is the same as the latest patch, except for my changes.