### PR TITLE
Resolves #135. Aristos optional diplobanner patch

### DIFF
--- a/Assets/Text/cqui_text_settings.xml
+++ b/Assets/Text/cqui_text_settings.xml
@@ -126,6 +126,9 @@
     <Row Tag="LOC_CQUI_GENERAL_SHOWLUXURY" Language="en_US">
       <Text>Show luxuries in top panel</Text>
     </Row>
+	<Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="en_US">
+      <Text>Show the Diplomacy Ribbon</Text>
+    </Row>
     <Row Tag="LOC_CQUI_GENERAL_SOLID" Language="en_US">
       <Text>Solid</Text>
     </Row>

--- a/Assets/Text/cqui_text_settings.xml
+++ b/Assets/Text/cqui_text_settings.xml
@@ -126,7 +126,7 @@
     <Row Tag="LOC_CQUI_GENERAL_SHOWLUXURY" Language="en_US">
       <Text>Show luxuries in top panel</Text>
     </Row>
-	  <Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="en_US">
+    <Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="en_US">
       <Text>Show the Diplomacy Ribbon</Text>
     </Row>
     <Row Tag="LOC_CQUI_GENERAL_SOLID" Language="en_US">

--- a/Assets/Text/cqui_text_settings.xml
+++ b/Assets/Text/cqui_text_settings.xml
@@ -126,7 +126,7 @@
     <Row Tag="LOC_CQUI_GENERAL_SHOWLUXURY" Language="en_US">
       <Text>Show luxuries in top panel</Text>
     </Row>
-	<Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="en_US">
+	  <Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="en_US">
       <Text>Show the Diplomacy Ribbon</Text>
     </Row>
     <Row Tag="LOC_CQUI_GENERAL_SOLID" Language="en_US">

--- a/Assets/Text/cqui_text_settings_de.xml
+++ b/Assets/Text/cqui_text_settings_de.xml
@@ -126,6 +126,9 @@
     <Row Tag="LOC_CQUI_GENERAL_SHOWLUXURY" Language="de_DE">
       <Text>Zeige Luxusgüter im Top-Panel.</Text>
     </Row>
+	<Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="de_DE">
+      <Text>Show the Diplomacy Ribbon</Text>
+    </Row>
     <Row Tag="LOC_CQUI_GENERAL_SOLID" Language="de_DE">
       <Text>Opak</Text>
     </Row>

--- a/Assets/Text/cqui_text_settings_de.xml
+++ b/Assets/Text/cqui_text_settings_de.xml
@@ -126,7 +126,7 @@
     <Row Tag="LOC_CQUI_GENERAL_SHOWLUXURY" Language="de_DE">
       <Text>Zeige Luxusgüter im Top-Panel.</Text>
     </Row>
-	<Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="de_DE">
+    <Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="de_DE">
       <Text>Show the Diplomacy Ribbon</Text>
     </Row>
     <Row Tag="LOC_CQUI_GENERAL_SOLID" Language="de_DE">

--- a/Assets/Text/cqui_text_settings_es.xml
+++ b/Assets/Text/cqui_text_settings_es.xml
@@ -108,6 +108,9 @@
     <Row Tag="LOC_CQUI_GENERAL_SHOWLUXURY" Language="es_ES">
       <Text>Muestra los lujos en el panel superior</Text>
     </Row>
+	<Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="es_ES">
+      <Text>Show the Diplomacy Ribbon</Text>
+    </Row>
     <Row Tag="LOC_CQUI_GENERAL_SOLID" Language="es_ES">
       <Text>Sólido</Text>
     </Row>

--- a/Assets/Text/cqui_text_settings_es.xml
+++ b/Assets/Text/cqui_text_settings_es.xml
@@ -108,7 +108,7 @@
     <Row Tag="LOC_CQUI_GENERAL_SHOWLUXURY" Language="es_ES">
       <Text>Muestra los lujos en el panel superior</Text>
     </Row>
-	<Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="es_ES">
+    <Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="es_ES">
       <Text>Show the Diplomacy Ribbon</Text>
     </Row>
     <Row Tag="LOC_CQUI_GENERAL_SOLID" Language="es_ES">

--- a/Assets/Text/cqui_text_settings_fr.xml
+++ b/Assets/Text/cqui_text_settings_fr.xml
@@ -86,6 +86,9 @@
     <Row Tag="LOC_CQUI_GENERAL_SHOWLUXURY" Language="fr_FR">
       <Text>Montrer les ressources de luxe dans le panel du haut</Text>
     </Row>
+	<Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="fr_FR">
+      <Text>Show the Diplomacy Ribbon</Text>
+    </Row>
     <Row Tag="LOC_CQUI_GENERAL_SOLID" Language="fr_FR">
       <Text>Solide</Text>
     </Row>

--- a/Assets/Text/cqui_text_settings_fr.xml
+++ b/Assets/Text/cqui_text_settings_fr.xml
@@ -86,7 +86,7 @@
     <Row Tag="LOC_CQUI_GENERAL_SHOWLUXURY" Language="fr_FR">
       <Text>Montrer les ressources de luxe dans le panel du haut</Text>
     </Row>
-	<Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="fr_FR">
+    <Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="fr_FR">
       <Text>Show the Diplomacy Ribbon</Text>
     </Row>
     <Row Tag="LOC_CQUI_GENERAL_SOLID" Language="fr_FR">

--- a/Assets/Text/cqui_text_settings_it.xml
+++ b/Assets/Text/cqui_text_settings_it.xml
@@ -126,6 +126,9 @@
     <Row Tag="LOC_CQUI_GENERAL_SHOWLUXURY" Language="it_IT">
       <Text>Risorse di lusso nel pannello superiore</Text>
     </Row>
+	<Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="it_IT">
+      <Text>Show the Diplomacy Ribbon</Text>
+    </Row>
     <Row Tag="LOC_CQUI_GENERAL_SOLID" Language="it_IT">
       <Text>Solido</Text>
     </Row>

--- a/Assets/Text/cqui_text_settings_it.xml
+++ b/Assets/Text/cqui_text_settings_it.xml
@@ -126,7 +126,7 @@
     <Row Tag="LOC_CQUI_GENERAL_SHOWLUXURY" Language="it_IT">
       <Text>Risorse di lusso nel pannello superiore</Text>
     </Row>
-	<Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="it_IT">
+    <Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="it_IT">
       <Text>Show the Diplomacy Ribbon</Text>
     </Row>
     <Row Tag="LOC_CQUI_GENERAL_SOLID" Language="it_IT">

--- a/Assets/Text/cqui_text_settings_ja.xml
+++ b/Assets/Text/cqui_text_settings_ja.xml
@@ -126,6 +126,9 @@
     <Row Tag="LOC_CQUI_GENERAL_SHOWLUXURY" Language="ja_JP">
       <Text>高級資源をトップパネルに表示</Text>
     </Row>
+	<Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="ja_JP">
+      <Text>Show the Diplomacy Ribbon</Text>
+    </Row>
     <Row Tag="LOC_CQUI_GENERAL_SOLID" Language="ja_JP">
       <Text>表示</Text>
     </Row>

--- a/Assets/Text/cqui_text_settings_ja.xml
+++ b/Assets/Text/cqui_text_settings_ja.xml
@@ -126,7 +126,7 @@
     <Row Tag="LOC_CQUI_GENERAL_SHOWLUXURY" Language="ja_JP">
       <Text>高級資源をトップパネルに表示</Text>
     </Row>
-	<Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="ja_JP">
+    <Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="ja_JP">
       <Text>Show the Diplomacy Ribbon</Text>
     </Row>
     <Row Tag="LOC_CQUI_GENERAL_SOLID" Language="ja_JP">

--- a/Assets/Text/cqui_text_settings_ko.xml
+++ b/Assets/Text/cqui_text_settings_ko.xml
@@ -102,6 +102,9 @@
     <Row Tag="LOC_CQUI_GENERAL_SHOWLUXURY" Language="ko_KR">
       <Text>상단 패널에 사치 자원 표시</Text>
     </Row>
+	<Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="ko_KR">
+      <Text>Show the Diplomacy Ribbon</Text>
+    </Row>
     <Row Tag="LOC_CQUI_GENERAL_SOLID" Language="ko_KR">
       <Text>불투명</Text>
     </Row>

--- a/Assets/Text/cqui_text_settings_ko.xml
+++ b/Assets/Text/cqui_text_settings_ko.xml
@@ -102,7 +102,7 @@
     <Row Tag="LOC_CQUI_GENERAL_SHOWLUXURY" Language="ko_KR">
       <Text>상단 패널에 사치 자원 표시</Text>
     </Row>
-	<Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="ko_KR">
+    <Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="ko_KR">
       <Text>Show the Diplomacy Ribbon</Text>
     </Row>
     <Row Tag="LOC_CQUI_GENERAL_SOLID" Language="ko_KR">

--- a/Assets/Text/cqui_text_settings_pl.xml
+++ b/Assets/Text/cqui_text_settings_pl.xml
@@ -108,7 +108,7 @@
     <Row Tag="LOC_CQUI_GENERAL_SHOWLUXURY" Language="pl_PL">
       <Text>Zasoby luksusowe w górnym panelu</Text>
     </Row>
-	<Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="pl_PL">
+    <Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="pl_PL">
       <Text>Show the Diplomacy Ribbon</Text>
     </Row>
     <Row Tag="LOC_CQUI_GENERAL_SOLID" Language="pl_PL">

--- a/Assets/Text/cqui_text_settings_pl.xml
+++ b/Assets/Text/cqui_text_settings_pl.xml
@@ -108,6 +108,9 @@
     <Row Tag="LOC_CQUI_GENERAL_SHOWLUXURY" Language="pl_PL">
       <Text>Zasoby luksusowe w górnym panelu</Text>
     </Row>
+	<Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="pl_PL">
+      <Text>Show the Diplomacy Ribbon</Text>
+    </Row>
     <Row Tag="LOC_CQUI_GENERAL_SOLID" Language="pl_PL">
       <Text>Pełny</Text>
     </Row>

--- a/Assets/Text/cqui_text_settings_pt.xml
+++ b/Assets/Text/cqui_text_settings_pt.xml
@@ -126,6 +126,9 @@
     <Row Tag="LOC_CQUI_GENERAL_SHOWLUXURY" Language="pt_BR">
       <Text>Mostrar luxos no painel superior</Text>
     </Row>
+	<Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="pt_BR">
+      <Text>Show the Diplomacy Ribbon</Text>
+    </Row>
     <Row Tag="LOC_CQUI_GENERAL_SOLID" Language="pt_BR">
       <Text>Sólido</Text>
     </Row>

--- a/Assets/Text/cqui_text_settings_pt.xml
+++ b/Assets/Text/cqui_text_settings_pt.xml
@@ -126,7 +126,7 @@
     <Row Tag="LOC_CQUI_GENERAL_SHOWLUXURY" Language="pt_BR">
       <Text>Mostrar luxos no painel superior</Text>
     </Row>
-	<Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="pt_BR">
+    <Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="pt_BR">
       <Text>Show the Diplomacy Ribbon</Text>
     </Row>
     <Row Tag="LOC_CQUI_GENERAL_SOLID" Language="pt_BR">

--- a/Assets/Text/cqui_text_settings_ru.xml
+++ b/Assets/Text/cqui_text_settings_ru.xml
@@ -108,7 +108,7 @@
     <Row Tag="LOC_CQUI_GENERAL_SHOWLUXURY" Language="ru_RU">
       <Text>Редкие ресурсы на верхней панели</Text>
     </Row>
-	<Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="ru_RU">
+    <Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="ru_RU">
       <Text>Show the Diplomacy Ribbon</Text>
     </Row>
     <Row Tag="LOC_CQUI_GENERAL_SOLID" Language="ru_RU">

--- a/Assets/Text/cqui_text_settings_ru.xml
+++ b/Assets/Text/cqui_text_settings_ru.xml
@@ -108,6 +108,9 @@
     <Row Tag="LOC_CQUI_GENERAL_SHOWLUXURY" Language="ru_RU">
       <Text>Редкие ресурсы на верхней панели</Text>
     </Row>
+	<Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="ru_RU">
+      <Text>Show the Diplomacy Ribbon</Text>
+    </Row>
     <Row Tag="LOC_CQUI_GENERAL_SOLID" Language="ru_RU">
       <Text>Сплошные</Text>
     </Row>

--- a/Assets/Text/cqui_text_settings_zh.xml
+++ b/Assets/Text/cqui_text_settings_zh.xml
@@ -102,6 +102,9 @@
     <Row Tag="LOC_CQUI_GENERAL_SHOWLUXURY" Language="zh_Hans_CN">
       <Text>在顶部面板显示奢侈</Text>
     </Row>
+	<Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="zh_Hans_CN">
+      <Text>Show the Diplomacy Ribbon</Text>
+    </Row>
     <Row Tag="LOC_CQUI_GENERAL_SOLID" Language="zh_Hans_CN">
       <Text>固定</Text>
     </Row>

--- a/Assets/Text/cqui_text_settings_zh.xml
+++ b/Assets/Text/cqui_text_settings_zh.xml
@@ -102,7 +102,7 @@
     <Row Tag="LOC_CQUI_GENERAL_SHOWLUXURY" Language="zh_Hans_CN">
       <Text>在顶部面板显示奢侈</Text>
     </Row>
-	<Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="zh_Hans_CN">
+    <Row Tag="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" Language="zh_Hans_CN">
       <Text>Show the Diplomacy Ribbon</Text>
     </Row>
     <Row Tag="LOC_CQUI_GENERAL_SOLID" Language="zh_Hans_CN">

--- a/Assets/UI/diplomacyribbon.lua
+++ b/Assets/UI/diplomacyribbon.lua
@@ -27,9 +27,11 @@ local m_scrollIndex			:number = 0; -- Index of leader that is supposed to be on 
 local m_scrollPercent		:number = 0; -- Necessary for scroll lerp
 local m_maxNumLeaders		:number = 0; -- Number of leaders that can fit in the ribbon
 local m_isScrolling			:boolean = false;
+local CQUI_IsDiploBannerOn = GameConfiguration.GetValue("CQUI_ShowDiploBanner"); --ARISTOS: controls the display of Diplo Banner
 local m_uiLeadersByID		:table = {};
 local m_uiChatIconsVisible	:table = {};
-local m_kLeaderIM			:table = InstanceManager:new("LeaderInstance", "LeaderContainer", Controls.LeaderStack);
+local m_kLeaderIM			:table = CQUI_IsDiploBannerOn and InstanceManager:new("LeaderInstance", "LeaderContainer", Controls.LeaderStack) 
+										or InstanceManager:new("LeaderInstanceNormal", "LeaderContainer", Controls.LeaderStack); --ARISTOS: to make Diplo Banner optional
 local m_PartialScreenHookBar: table;	-- = ContextPtr:LookUpControl( "/InGame/PartialScreenHooks/LaunchBacking" );
 local m_LaunchBar			: table;	-- = ContextPtr:LookUpControl( "/InGame/LaunchBar/LaunchBacking" );
 
@@ -46,6 +48,16 @@ function ResetLeaders()
   m_uiLeadersByID = {};
   m_kLeaderIM:ResetInstances();
 end
+
+--ARISTOS: Update Diplo Banner display status
+function CQUI_OnSettingsUpdate()
+  CQUI_IsDiploBannerOn = GameConfiguration.GetValue("CQUI_ShowDiploBanner");
+  ResetLeaders();
+  m_kLeaderIM = CQUI_IsDiploBannerOn and InstanceManager:new("LeaderInstance", "LeaderContainer", Controls.LeaderStack) 
+										or InstanceManager:new("LeaderInstanceNormal", "LeaderContainer", Controls.LeaderStack); --ARISTOS: to make Diplo Banner optional
+  UpdateLeaders();
+end
+LuaEvents.CQUI_SettingsUpdate.Add( CQUI_OnSettingsUpdate );
 
 -- ===========================================================================
 function OnLeaderClicked(playerID : number )
@@ -194,9 +206,12 @@ function AddLeader(iconName : string, playerID : number, isUniqueLeader: boolean
   end
 
   -- CQUI: Set score values for DRS display
-  instance.CQUI_ScoreOverall:SetText("[ICON_Capital]"..Players[playerID]:GetScore());
-  instance.CQUI_ScienceRate:SetText("[ICON_Science]"..Round(Players[playerID]:GetTechs():GetScienceYield(),0));
-  instance.CQUI_MilitaryStrength:SetText("[ICON_Strength]"..Players[playerID]:GetStats():GetMilitaryStrength());
+  --ARISTOS: only if Diplo Banner ON
+  if CQUI_IsDiploBannerOn then
+	instance.CQUI_ScoreOverall:SetText("[ICON_Capital]"..Players[playerID]:GetScore());
+	instance.CQUI_ScienceRate:SetText("[ICON_Science]"..Round(Players[playerID]:GetTechs():GetScienceYield(),0));
+	instance.CQUI_MilitaryStrength:SetText("[ICON_Strength]"..Players[playerID]:GetStats():GetMilitaryStrength());
+  end
 
   instance.Relationship:SetHide(not bShowRelationshipIcon);
   -- Set the tooltip

--- a/Assets/UI/diplomacyribbon.lua
+++ b/Assets/UI/diplomacyribbon.lua
@@ -208,9 +208,9 @@ function AddLeader(iconName : string, playerID : number, isUniqueLeader: boolean
   -- CQUI: Set score values for DRS display
   --ARISTOS: only if Diplo Banner ON
   if CQUI_IsDiploBannerOn then
-	instance.CQUI_ScoreOverall:SetText("[ICON_Capital]"..Players[playerID]:GetScore());
-	instance.CQUI_ScienceRate:SetText("[ICON_Science]"..Round(Players[playerID]:GetTechs():GetScienceYield(),0));
-	instance.CQUI_MilitaryStrength:SetText("[ICON_Strength]"..Players[playerID]:GetStats():GetMilitaryStrength());
+	  instance.CQUI_ScoreOverall:SetText("[ICON_Capital]"..Players[playerID]:GetScore());
+	  instance.CQUI_ScienceRate:SetText("[ICON_Science]"..Round(Players[playerID]:GetTechs():GetScienceYield(),0));
+	  instance.CQUI_MilitaryStrength:SetText("[ICON_Strength]"..Players[playerID]:GetStats():GetMilitaryStrength());
   end
 
   instance.Relationship:SetHide(not bShowRelationshipIcon);

--- a/Assets/UI/diplomacyribbon.lua
+++ b/Assets/UI/diplomacyribbon.lua
@@ -665,6 +665,7 @@ function Initialize()
   LuaEvents.WorldTracker_OnChatShown.Add(OnChatPanelShown);
   LuaEvents.LaunchBar_Resize.Add(RealizeSize);
   LuaEvents.PartialScreenHooks_Resize.Add(RealizeSize);
+  LuaEvents.CQUI_SettingsInitialized.Add(CQUI_OnSettingsUpdate);
 
   Controls.NextButton:RegisterCallback( Mouse.eLClick, OnScrollLeft );
   Controls.PreviousButton:RegisterCallback( Mouse.eLClick, OnScrollRight );

--- a/Assets/UI/diplomacyribbon.xml
+++ b/Assets/UI/diplomacyribbon.xml
@@ -58,5 +58,14 @@
         </Grid>
       </SlideAnim>
   </Instance>
+  
+  <Instance Name="LeaderInstanceNormal">
+      <SlideAnim ID="LeaderContainer" Size="52,52" Offset="0,0" Begin="0,0" EndOffset="0,20" Cycle="Once" Stopped="1">
+				<MakeInstance Name="LeaderIcon45"/>
+				<AlphaAnim ID="ChatIndicatorFade" Cycle="Once" AlphaBegin="0.0" AlphaEnd="1.0" Speed="3" Stopped="1">
+					<Image ID="ChatIndicator" Hidden="0" Offset="35,0" Size="22,22" Texture="DiploRibbon_TypingIndicator"/>
+				</AlphaAnim>
+      </SlideAnim>
+  </Instance>
 
 </Context>

--- a/Assets/cqui_settings.sql
+++ b/Assets/cqui_settings.sql
@@ -64,7 +64,7 @@ INSERT OR REPLACE INTO CQUI_Settings -- Don't touch this line!
       ('CQUI_ShowTechCivicRecommendations', 1), -- Shows the advisor recommendation in the techs/civics tree/panel
       ('CQUI_ShowImprovementsRecommendations', 0), -- Shows the advisor recommendation for the builder improvements
       ('CQUI_ShowCityDetailAdvisor', 0), -- Shows the advisor recommendation in the city detail panel
-	  ('CQUI_ShowDiploBanner', 1), -- Shows the Diplomacy Banner
+      ('CQUI_ShowDiploBanner', 1), -- Shows the Diplomacy Banner
       ('CQUI_ShowDebugPrint', 0); -- Shows print in the console
 /*
     ┌────────────────────────────────────────────────────────────────────────────────────────────┐

--- a/Assets/cqui_settings.sql
+++ b/Assets/cqui_settings.sql
@@ -64,6 +64,7 @@ INSERT OR REPLACE INTO CQUI_Settings -- Don't touch this line!
       ('CQUI_ShowTechCivicRecommendations', 1), -- Shows the advisor recommendation in the techs/civics tree/panel
       ('CQUI_ShowImprovementsRecommendations', 0), -- Shows the advisor recommendation for the builder improvements
       ('CQUI_ShowCityDetailAdvisor', 0), -- Shows the advisor recommendation in the city detail panel
+	  ('CQUI_ShowDiploBanner', 1), -- Shows the Diplomacy Banner
       ('CQUI_ShowDebugPrint', 0); -- Shows print in the console
 /*
     ┌────────────────────────────────────────────────────────────────────────────────────────────┐

--- a/Assets/cqui_settingselement.lua
+++ b/Assets/cqui_settingselement.lua
@@ -313,6 +313,7 @@ function Initialize()
   PopulateCheckBox(Controls.ProductionQueueCheckbox, "CQUI_ProductionQueue");
   RegisterControl(Controls.ProductionQueueCheckbox, "CQUI_ProductionQueue", UpdateCheckbox);
   PopulateCheckBox(Controls.ShowLuxuryCheckbox, "CQUI_ShowLuxuries");
+  PopulateCheckBox(Controls.ShowDiploBannerCheckbox, "CQUI_ShowDiploBanner");
   PopulateCheckBox(Controls.ShowCultureGrowthCheckbox, "CQUI_ShowCultureGrowth", Locale.Lookup("LOC_CQUI_CITYVIEW_SHOWCULTUREGROWTH_TOOLTIP"));
   RegisterControl(Controls.ShowCultureGrowthCheckbox, "CQUI_ShowCultureGrowth", UpdateCheckbox);
   PopulateCheckBox(Controls.SmartbannerCheckbox, "CQUI_Smartbanner", Locale.Lookup("LOC_CQUI_CITYVIEW_SMARTBANNER_TOOLTIP"));

--- a/Assets/cqui_settingselement.xml
+++ b/Assets/cqui_settingselement.xml
@@ -35,6 +35,9 @@
             <GridButton ID="ShowLuxuryCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_GENERAL_SHOWLUXURY" />
           </Stack>
 		  <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
+            <GridButton ID="ShowDiploBannerCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" />
+          </Stack>
+		  <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
 			<GridButton ID="ShowPolicyReminderCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_GENERAL_SHOWPRD" />
           </Stack>
           <Stack Anchor="R,T" StackGrowth="Left" Padding="5">

--- a/Assets/cqui_settingselement.xml
+++ b/Assets/cqui_settingselement.xml
@@ -34,7 +34,7 @@
           <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
             <GridButton ID="ShowLuxuryCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_GENERAL_SHOWLUXURY" />
           </Stack>
-		  <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
+          <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
             <GridButton ID="ShowDiploBannerCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_GENERAL_SHOWDIPLOBANNER" />
           </Stack>
 		  <Stack Anchor="R,T" StackGrowth="Left" Padding="5">


### PR DESCRIPTION
Resolves #135. Makes the diplo banner optional by including a variable in the settings file and adding a toggle to the general CQUI settings. Localization files have been initialized but all non-english values require translations.