### PR TITLE
Fixes #44 & #140 (better mouse edge scrolling)

### DIFF
--- a/Assets/UI/Panels/notificationpanel.xml
+++ b/Assets/UI/Panels/notificationpanel.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Context xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="..\..\..\..\..\CivTech\Libs\ForgeUI\ForgeUI_Assets\Controls.xsd">
+	
+  <Image															Anchor="R,B" Texture="ActionPanel_Backing.dds"/>
+  <SlideAnim        ID="RailOffsetAnim" Anchor="R,B" Size="parent,parent" Begin="0,-70" End="0,0" Cycle="Once" Speed="1" Function="OutQuint" Stopped="1">
+    <SlideAnim				ID="RailAnim"			Anchor="R,B" Size="1,1"		Offset="0,60" Begin="0,-260" End="0,0" Cycle="Once" Speed="1" Function="OutQuint">
+      <Stack Anchor="R,B" Offset="-5,-5" StackGrowth="Down" Padding="0">
+        <Image Texture="ActionPanel_RailTopper.dds"  Size="39,41"/>
+        <Image ID="RailImage" Texture="ActionPanel_Rail"    Size ="39,89" StretchMode="Tile"/>
+      </Stack>
+    </SlideAnim>
+    <Grid AnchorSide="O,I" Offset="-2,0" Texture="Controls_ScrollBarBacking" Size="15,parent" SliceTextureSize="11,11" SliceCorner="5,5" Anchor="R,B" Color="111,101,94,180"/>
+    <Container				ID="Items"/>
+    <Container				ID="Groups"/>
+
+    <!-- The offset of the scrollpanel (300) is to accommodate the height of the ActionPanel AND Purchase Tile/Manage Citizens buttons -->
+    <!-- The relative size of the scrollpanel height (parent-285) is to accommodate the height of the ActionPanel AND the hieght of the top bar-->
+    <ScrollPanel			ID="ScrollPanel"	Anchor="R,B"	Offset="0,300"	Size="62,parent-280"				Vertical="1" AutoScollbar="1" FullClip="0" HasExternalChildren="1">
+			<Stack					ID="ScrollStack"	Anchor="R,B"	Offset="0,0"		StackGrowth="Top"		Padding="-10"  />
+			<ScrollBar			ID="ScrollBar"		Anchor="R,C"									Size="11,14"				AnchorSide="O,I"  Texture="Controls_ScrollbarV" StateOffsetIncrement="0,0" Vertical="1" SliceCorner="5,5" SliceTextureSize="11,14" Color="0,0,0,120" >
+        <Thumb																										Size="13,13"					Texture="Controls_ScrollBarHandleV_Brown" StateOffsetIncrement="0,0" SliceCorner="6,6" SliceTextureSize="13,13"/>
+      </ScrollBar>
+    </ScrollPanel>
+  </SlideAnim>
+
+
+
+  <!-- ====================================================================	-->
+  <!--	Instances																														-->
+  <!-- ====================================================================	-->
+
+  <Instance							Name="GroupInstance">
+    <Container					ID="Top"								Anchor="R,C"  Offset="0,0"	Size="96,62"	ConsumeMouse="1">
+      <Button						ID="GroupButton"				Anchor="R,C"	Offset="0,0"	Size="65,66"	Texture="ActionPanel_NotificationGrouped.dds" NoStateChange="1">
+        <Image            ID="Icon"               Size="40,40"  Texture="Notifications40" Anchor="C,C"/>
+      </Button>
+    </Container>
+  </Instance>
+
+  <Instance							Name="ItemInstance">
+    <Container					ID="Top"								Anchor="R,C"	Offset="0,0"		Size="62,72" >
+      <ScrollPanel			ID="Clip"								Anchor="L,C"	Offset="-43,0"	Size="2048,66" AnchorSide="O,O" Vertical="0">
+        <SlideAnim			ID="NotificationSlide"	Anchor="R,C"	Start="-250,0"	EndOffset="0,0"		Size="255,60" Speed="3" Cycle="Once" FunctionPower="3" Function="Root" Stopped="1">
+          <Grid					ID="ExpandedArea"				Anchor="L,C"	Size="250,70"		InnerPadding="35,0"										Texture="ActionPanel_Flyout" SliceTextureSize="64,64" SliceCorner="32,32" ConsumeMouse="1" d="0">
+
+						<Button			ID="LeftArrow"					Anchor="R,C"	Offset="7,5"		Size="19,23"				Texture="Controls_ArrowButtonLeft"						Hidden="1" ConsumeMouse="1"/>
+						<Button			ID="RightArrow"					Anchor="R,C"	Offset="-13,5"	Size="19,23"				Texture="Controls_ArrowButtonRight"						Hidden="1" ConsumeMouse="1"/>
+						
+						<Stack			ID="TitleStack"					Anchor="C,T"	Offset="0,3"	 Size="auto,26" StackGrowth="Right" Padding="4" >
+              <Label		ID="TitleCount"					Anchor="L,C"																			Style="FlairShadow26"				ColorEffect="0,0,0,255" FontStyle="Shadow" String="" Offset="-20,0" />
+              <Label		ID="TitleInfo"					Anchor="L,C"	Offset="0,1"												Style="NotificationHeader"	String="$ActionInfo$" />
+            </Stack>
+						
+            <Label			ID="Summary"						Anchor="C,T"	Offset="0,27"			LeadingOffset="1"                 Style="WhiteSemiBold12"     String="$ActionDetails$"/>
+            <Stack			ID="PagePipStack"				Anchor="C,B"	Offset="0,8"		StackGrowth="Right" Padding="1"																		Hidden="1"	/>
+            <Label			ID="Pages"							Anchor="C,B"	Offset="0,9" Style="FontFlair14" FontStyle="glow" Color0="208,212,217,255" Color1="0,0,0,200" String="#/#" Hidden="1"	/>
+          </Grid>
+        </SlideAnim>
+      </ScrollPanel>
+
+      <Button				ID="MouseInArea"						Anchor="R,C" Size="65,60" ConsumeMouse="0" d="0" />
+			<Button				ID="MouseOutArea"						Anchor="R,C" Size="321,60" Disabled="0" Hidden="1" d="0"  />
+
+			<Image						ID="IconBG"								Anchor="R,C"	Offset="0,0"	Size="65,66"	Texture="ActionPanel_Notification.dds" >
+        <Image            ID="Icon"               Size="40,40"  Texture="Notifications40" Anchor="C,C" Offset="-2,-2"/>
+      </Image>
+
+			<Image						ID="IconBGInvalidPhase"			Anchor="R,C"	Offset="0,0"	Size="65,66"  Texture="ActionPanel_Notification.dds" Color="Civ6Red" Hidden="1" />
+      <Image						ID="CountImage"							Anchor="R,B"	Offset="0,-4" Texture="ActionPanel_Badge" Hidden="0" >
+        <Label					ID="Count"									Anchor="C,C"	Offset="4,4"	Style="FontFlair14" String="3" />
+        <Button         ID="DismissStackButton"     Anchor="R,B"  Offset="5,5" Size="20,20"/>
+      </Image>
+    </Container>
+  </Instance>
+
+  <Instance							Name="ButtonInstance">
+    <Button							ID="Button"							Size="50,50"	Texture="ActionPanel_Notification2" NoStateChange="1">
+      <Image            ID="Icon"               Size="40,40"  Texture="Notifications40" Anchor="C,C"/>
+    </Button>
+  </Instance>
+
+  <Instance							Name="PipInstance">
+    <Image							ID="Pip"							Size="9,10"					Texture="Controls_Bolt" />
+  </Instance>
+
+</Context>

--- a/Assets/UI/Panels/unitpanel.xml
+++ b/Assets/UI/Panels/unitpanel.xml
@@ -13,7 +13,7 @@
         </Button>
         <Stack					ID="BuildActionsStack"				Anchor="R,T" Offset="11,26" StackGrowth="Left" Padding="6" />
       </Grid>
-      <Container				ID="UnitPanelBaseContainer" Anchor="R,B" Offset="172,0" Size="310,160" ConsumeMouseOver="1" >
+      <Container				ID="UnitPanelBaseContainer" Anchor="R,B" Offset="172,2" Size="310,160" ConsumeMouseOver="1" >
         <Grid						ID="MainPanelBacking"				Anchor="R,B" Texture="SelectionPanel_WoodBacking" SliceTextureSize="150,154" SliceCorner="85,47" Size="Parent-10,Parent-6">
           <Grid																			AnchorSide="I,O" Texture="SelectionPanel_TopRim" SliceTextureSize="14,5" SliceCorner="7,2" Size="parent,5"/>
         </Grid>

--- a/Assets/UI/actionpanel.xml
+++ b/Assets/UI/actionpanel.xml
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<Context>
+  <Stack							ID="NotificationStack"		Anchor="R,B" Offset="57,50" StackGrowth="Up" />
+
+	<Container																		Anchor="R,B"									Size="190,215" Offset="2,10">
+    <Image																			Anchor="R,B" Offset="-7,25"		Texture="ActionPanel_LittleGear.dds" />
+    <Image																			Anchor="R,B" Offset="0,-6"	Texture="ActionPanel_WoodenRim.dds" ConsumeAllMouse="1" Size="177,183"/>
+		<Container				ID="EraToolTipArea1"			Anchor="R,B" Offset="0,45"		Size="30,105" />
+		<Container				ID="EraToolTipArea2"			Anchor="R,B" Offset="30,135"	Size="42,36"	/>
+		
+    <FlipAnim					ID="TickerAnim"						Anchor="R,B" Offset="0,-14"		Size="52,60" Texture="ActionPanel_ClickerAnim" FrameCount="10" Columns="5" Speed="30" Cycle="OneBounce"/>
+    
+    <AlphaAnim				ID="OverflowHandleAlpha"	AlphaBegin="0" AlphaEnd="1" Speed="5" Cycle="Once" Pause=".6" Hidden="1">
+      <SlideAnim			ID="OverflowHandleSlide"	Anchor="L,T"									Size="parent,parent" Begin="-30,20" End="0,0" Cycle="Once" Speed="1" Function="OutQuint" Pause=".6">
+        <Button																	Anchor="L,B" Offset="75,152"	Size="27,11" Texture="ActionPanel_OverflowHandle"  StateOffsetIncrement="0,0" />
+      </SlideAnim>		
+    </AlphaAnim>
+    <AlphaAnim				ID="TurnBlockerAlpha4"		AlphaBegin="0" AlphaEnd="1" Speed="5" Cycle="Once" Pause=".4" Hidden="1">
+      <SlideAnim			ID="TurnBlockerSlide4"		Anchor="L,T"									Size="parent,parent" Begin="-20,20" End="0,0" Cycle="Once" Speed="1" Function="OutQuint" Pause=".4">
+				<Image																	Anchor="L,B" Offset="29,120"	Size="60,60"	Texture="ActionPanel_TurnBlocker3"   StateOffsetIncrement="0,0" >
+          <Button	ID="TurnBlockerButton4"		Anchor="C,C"		 Offset="3,-2"							Size="40,40"  StateOffsetIncrement="0,0" Texture="Notifications40"/>
+				</Image>
+			</SlideAnim>		
+    </AlphaAnim>
+    <AlphaAnim				ID="TurnBlockerAlpha3"		AlphaBegin="0" AlphaEnd="1" Speed="5" Cycle="Once" Pause=".2" Hidden="1">
+      <SlideAnim			ID="TurnBlockerSlide3"		Anchor="L,T"									Size="parent,parent" Begin="0,30" End="0,0" Cycle="Once" Speed="1" Function="OutQuint" Pause=".2">
+				<Image																	Anchor="L,B" Offset="2,68"		Size="50,71"	Texture="ActionPanel_TurnBlocker2"   StateOffsetIncrement="0,0">
+          <Button	ID="TurnBlockerButton3"		Anchor="C,T" Offset="3,7" Size="40,40"  StateOffsetIncrement="0,0"  Texture="Notifications40" />
+				</Image>
+      </SlideAnim>		
+    </AlphaAnim>
+    <AlphaAnim				ID="TurnBlockerAlpha2"		AlphaBegin="0" AlphaEnd="1" Speed="5" Cycle="Once"						Hidden="1">
+      <SlideAnim			ID="TurnBlockerSlide2"		Anchor="L,T"								Size="parent,parent" Begin="10,20" End="0,0" Cycle="Once" Speed="1" Function="OutQuint" >
+				<Image																	Anchor="L,B" Offset="1,24"	Size="59,62"	Texture="ActionPanel_TurnBlocker1"   StateOffsetIncrement="0,0">
+					<Button	ID="TurnBlockerButton2"		Anchor="C,C" Offset="-1,-4" Size="40,40"  StateOffsetIncrement="0,0"  Texture="Notifications40" />
+				</Image>
+      </SlideAnim>
+    </AlphaAnim>
+		
+    <Image																						Anchor="R,B"	Offset="14,6" Texture="ActionPanel_Gold1.dds"  />
+		
+    <AlphaAnim			ID="TurnBlockerContainerAlpha"		AlphaBegin="0" AlphaEnd="1" Speed="5" Cycle="Once" Stopped="1"  Hidden="1">
+      <SlideAnim		ID="TurnBlockerContainerSlide"		Anchor="L,T"										Size="parent,parent"		Begin="0,20" End="0,0" Cycle="Once" Speed="1" Function="OutQuint" Stopped="1">
+        <Grid				ID="OverflowContainer"						Anchor="R,B"	Offset="0,168"		Size="230,130"	Texture="ActionPanel_TurnBlocker" NoStateChange="1" SliceCorner="20,25" SliceTextureSize="171,48" >
+          <Stack		ID="OverflowStack"								Offset="10,7" />
+        </Grid>
+      </SlideAnim>
+    </AlphaAnim>		
+    <AlphaAnim			ID="OverflowAlpha"								AlphaBegin="0" AlphaEnd="1" Speed="5" Cycle="Once" Pause=".6" Hidden="0">
+      <SlideAnim		ID="OverflowSlide"								Anchor="L,T"										Size="parent,parent" Begin="-30,20" End="0,0" Cycle="Once" Speed="1" Function="OutQuint"  Pause=".6">
+        <Image			ID="OverflowCheckboxGroup"																	Anchor="L,B"	Offset="82,134"		Size="50,50" Color="0,0,0,255" Texture="Controls_Glow2" >
+          <CheckBox	ID="OverflowCheckbox"							Anchor="C,T"	ButtonTexture="Controls_ButtonPlus_Up" ButtonSize="36,36" UseSelectedTextures="1" CheckTexture="Controls_Bolt" CheckColor="0,0,0,0" />
+        </Image>
+      </SlideAnim>
+    </AlphaAnim>		
+	
+    <Button					ID="EndTurnButtonLabel"						Anchor="R,B"	Offset="-2,167"	Size="171,48"					Texture="ActionPanel_TurnBlocker.dds" NoStateChange="1">
+		<AlphaAnim Anchor="C,C" Cycle="Bounce" Speed="1" AlphaStart="1" AlphaEnd="0.2" Pause="3" >
+			<Label				ID="EndTurnText"									Align="C,C" Anchor="C,C"	Offset="0,-3"	WrapWidth="165"					Style="ActionPanelText"	String="LOC_ACTION_PANEL_END_TURN" />
+		</AlphaAnim>
+    </Button>
+  
+		<Image																						Anchor="R,B"																				Texture="ActionPanel_Gold2.dds" Offset="20,2" >
+
+			<Container ID="TurnTimerContainer" Size="148,147" Hidden="1">
+				<Container Size="138,41" Offset="12,-7" Anchor="C,B">
+					<Grid ID="TurnTimerLabelBG" Offset="0,0" Anchor="C,B" Size="40,41" Texture="UnitPanel_ActionGroupSlot" SliceCorner="5,0" SliceSize="2,41" SliceTextureSize="12,41"/>
+					<Label ID="TurnTimerLabel" Offset="0,7" Anchor="C,B" Style="ActionPanelText"/>
+				</Container>
+				<Container Size="138,138" Offset="14,-2" >
+					<Image ID="TurnTimerMeterBG" Anchor="C,C"	Texture="ActionPanel_MultiplayerTimerBacking"/>
+					<Meter ID="TurnTimerMeter" Anchor="C,C" Offset="0,-4"	Size="116,117" Texture="ActionPanel_MultiplayerTimerFill" Speed="0"/>
+				</Container>
+			</Container>
+			
+			<Image				ID="EraIndicator"																Offset="0,-15"	Rotate="90"						Texture="ActionPanel_EraIndicator"  />
+      <FlipAnim FrameCount="17" Texture="ActionPanel_TurnProcessing" Columns="8" Anchor="R,B" Size="102,102" Offset="15,32" Stopped="0"/>
+			<BoxButton				ID="EndTurnButton"								Anchor="R,B"	Offset="11,28"	Size="108,108"				Color="0,0,0,0" NoStateChange="1">
+        <Image      ID="CurrentTurnBlockerIcon"             Anchor="C,C" Texture="Notifications100" Size="100,100"/>
+				<AlphaAnim	ID="EndTurnButtonProductionAlpha" Anchor="C,C"									Size="parent,parent"  Cycle="Bounce" Speed="1" AlphaStart=".4" AlphaEnd="0" Hidden="1" >
+					<Image																			Anchor="C,C"																				Texture="ActionPanel_EndTurnFlash.dds" />
+				</AlphaAnim>
+				<AlphaAnim	ID="EndTurnButtonScienceAlpha"		Anchor="C,C"									Size="parent,parent"  Cycle="Bounce" Speed="1" AlphaStart=".4" AlphaEnd="0" Hidden="1" >
+					<Image																			Anchor="C,C"																				Texture="ActionPanel_EndTurnFlash.dds" />
+				</AlphaAnim>
+				<AlphaAnim	ID="EndTurnButtonFreeTechAlpha"		Anchor="C,C"									Size="parent,parent"  Cycle="Bounce" Speed="1" AlphaStart=".4" AlphaEnd="0" Hidden="1" >
+					<Image																			Anchor="C,C"																				Texture="ActionPanel_EndTurnFlash.dds" />
+				</AlphaAnim>
+				<AlphaAnim	ID="EndTurnButtonEndTurnAlpha"		Anchor="C,C"									Size="parent,parent"  Cycle="Once" Speed="1" AlphaStart=".4" AlphaEnd="0" Hidden="1" >
+					<Image																			Anchor="C,C"																				Texture="ActionPanel_EndTurnFlash.dds" />
+				</AlphaAnim>				
+			</BoxButton>
+
+			<AlphaAnim		ID="TutorialSlowTurnEnableAnim"			Anchor="R,B" Speed="0.5" Offset="-20,0" Size="180,220" AlphaStart="1" AlphaEnd="1" Cycle="Once" ConsumeAllMouse="1" Hidden="1" />
+			
+		</Image>
+		
+		<Tutorial	   			ID="TutNotificationPointer"	Style="TutorialContainer"			Anchor="L,T"	Offset="-40,0"	TriggerBy="TutorialNotificationPointer" >
+			<SlideAnim																			Start="0,0"		EndOffset="-20,0" Cycle="Bounce" Function="OutQuad" >
+				<Image																			Offset="0,0"	Size="58,44"		Texture="Tutorial_ArrowH" />
+			</SlideAnim>
+		</Tutorial>
+
+		<Tutorial   			ID="TutSelectEndTurnAction"	Style="TutorialContainer"			Anchor="C,T"	Offset="5,50"	AnchorSide="O,O"  TriggerBy="TutorialSelectEndTurn">
+			<Grid																																					Style="TutorialEndTurnCalloutGrid">
+				<Label																			Style="TutorialEndTurnHeaderText"					String="LOC_META_5_HEAD" />
+				<Label																			Style="TutorialEndTurnBodyText"	String="LOC_META_5_BODY" />
+			</Grid>
+			<SlideAnim																			Start="0,-15"		EndOffset="0,-20" Cycle="Bounce" Function="OutQuad" Anchor="C,B">
+				<Image																			Offset="-20,-35"	Size="44,58"		Texture="Tutorial_ArrowV" />
+			</SlideAnim>
+		</Tutorial>
+
+		<Tutorial   			ID="TutSelectEndTurnActionB"	Style="TutorialContainer"			Anchor="C,T"	Offset="5,50"	AnchorSide="O,O"  TriggerBy="TutorialSelectEndTurnB" >
+			<Grid																																					Style="TutorialEndTurnCalloutGrid"  >
+				<Label																			Style="TutorialEndTurnHeaderText"					String="LOC_META_8_HEAD" />
+				<Label																			Style="TutorialEndTurnBodyText"	String="LOC_META_8_BODY" />
+			</Grid>
+		  <SlideAnim																			Start="0,-15"		EndOffset="0,-20" Cycle="Bounce" Function="OutQuad" Anchor="C,B">
+			<Image																			Offset="-20,-35"	Size="44,58"		Texture="Tutorial_ArrowV" />
+		  </SlideAnim>
+		</Tutorial>
+		
+		<Tutorial   			ID="TutSelectEndTurnActionC"	Style="TutorialContainer"			Anchor="C,T"	Offset="5,50"	AnchorSide="O,O"  TriggerBy="TutorialSelectEndTurnC" >
+			<Grid																				Style="TutorialEndTurnCalloutGrid"  >
+				<Label																			Style="TutorialEndTurnHeaderText"		String="LOC_META_11_HEAD" />
+				<Label																			Style="TutorialEndTurnBodyText"			String="LOC_META_11_BODY" />
+			</Grid>
+			<SlideAnim																			Start="0,-20"		EndOffset="0,-20" Cycle="Bounce" Function="OutQuad" Anchor="C,B">
+				<Image																			Offset="-20,-35"	Size="44,58"		Texture="Tutorial_ArrowV" />
+			</SlideAnim>
+		</Tutorial>
+
+		<Tutorial   			ID="TutSelectEndTurnActionD"	Style="TutorialContainer"			Anchor="C,T"	Offset="5, 50"	AnchorSide="O,O"  TriggerBy="TutorialSelectEndTurnD">
+			<Grid																																					Style="TutorialEndTurnCalloutGrid"  >
+				<Label																			Style="TutorialEndTurnHeaderText"					String="LOC_META_13_HEAD" />
+				<Label																			Style="TutorialEndTurnBodyText"	String="LOC_META_13_BODY" />
+			</Grid>
+		  <SlideAnim																			Start="0,-20"		EndOffset="0,-20" Cycle="Bounce" Function="OutQuad" Anchor="C,B">
+			<Image																			Offset="-20,-35"	Size="44,58"		Texture="Tutorial_ArrowV" />
+		  </SlideAnim>
+		</Tutorial>
+		
+		<Tutorial   			ID="TutSelectEndTurnActionE"	Style="TutorialContainer"			Anchor="C,T"	Offset="5, 50"	AnchorSide="O,O"  TriggerBy="TutorialSelectEndTurnE">
+			<Grid																																				Style="TutorialEndTurnCalloutGrid"  >
+				<Label																			Style="TutorialEndTurnHeaderText"					String="LOC_META_19_HEAD" />
+				<Label																			Style="TutorialEndTurnBodyText"	String="LOC_META_19b_BODY" />
+			</Grid>
+      <SlideAnim																			Start="0,-10"		EndOffset="0,-20" Cycle="Bounce" Function="OutQuad" Anchor="C,B">
+        <Image																			Offset="-20,-35"	Size="44,58"		Texture="Tutorial_ArrowV" />
+      </SlideAnim>
+		</Tutorial>
+
+		<Tutorial   			ID="TutSelectEndTurnActionF"	Style="TutorialContainer"			Anchor="C,T"	Offset="0,50"	AnchorSide="O,O"  TriggerBy="TutorialSelectEndTurnF"  >
+			<Grid																																					Style="TutorialEndTurnCalloutGrid"  >
+				<Label																			Style="TutorialEndTurnHeaderText"					String="LOC_META_27_HEAD" />
+				<Label																			Style="TutorialEndTurnBodyText"	String="LOC_META_27_BODY" />
+			</Grid>
+      <SlideAnim																			Start="0,0"		EndOffset="0,-20" Cycle="Bounce" Function="OutQuad" Anchor="C,B">
+        <Image																			Offset="-20,-35"	Size="44,58"		Texture="Tutorial_ArrowV" />
+      </SlideAnim>
+		</Tutorial>
+
+		<Tutorial   			ID="TutSelectEndTurnActionI"	Style="TutorialContainer"			Anchor="C,T"	Offset="5, 50"	AnchorSide="O,O"  TriggerBy="TutorialSelectEndTurnI">
+			<Grid																																					Style="TutorialEndTurnCalloutGrid"   >
+				<Label																			Style="TutorialEndTurnHeaderText"					String="LOC_META_33b_HEAD" />
+				<Label																			Style="TutorialEndTurnBodyText" String="LOC_META_33b_BODY" />
+			</Grid>
+      <SlideAnim																			Start="0,-15"		EndOffset="0,-20" Cycle="Bounce" Function="OutQuad" Anchor="C,B">
+        <Image																			Offset="-20,-35"	Size="44,58"		Texture="Tutorial_ArrowV" />
+      </SlideAnim>
+		</Tutorial>
+
+		<Tutorial   			ID="TutSelectEndTurnActionH"	Style="TutorialContainer"			Anchor="C,T"	Offset="5, 50"	AnchorSide="O,O"  TriggerBy="TutorialSelectEndTurnH"  >
+			<Grid																																					Style="TutorialEndTurnCalloutGrid"  >
+				<Label																			Style="TutorialEndTurnHeaderText"					String="LOC_META_34_HEAD" />
+				<Label																			Style="TutorialEndTurnBodyText"	String="LOC_META_34_BODY" />
+			</Grid>
+      <SlideAnim																			Start="0,0"		EndOffset="0,-20" Cycle="Bounce" Function="OutQuad" Anchor="C,B">
+        <Image																			Offset="-20,-35"	Size="44,58"		Texture="Tutorial_ArrowV" />
+      </SlideAnim>
+		</Tutorial>
+
+		<Tutorial   			ID="TutSelectEndTurnActionG"	Style="TutorialContainer"			Anchor="C,T"	Offset="5, 50"	AnchorSide="O,O"  TriggerBy="TutorialSelectEndTurnG">
+			<Grid																																					Style="TutorialEndTurnCalloutGrid"  >
+        <Label																			Style="TutorialEndTurnHeaderText"					String="LOC_META_6_HEAD" />
+				<Label																			Style="TutorialEndTurnBodyText"	String="LOC_META_6_BODY" />
+			</Grid>
+      <SlideAnim																			Start="0,-15"		EndOffset="0,-20" Cycle="Bounce" Function="OutQuad" Anchor="C,B">
+        <Image																			Offset="-20,-35"	Size="44,58"		Texture="Tutorial_ArrowV" />
+      </SlideAnim>
+		</Tutorial>
+
+		<Tutorial   			ID="TutSelectEndTurnActionIrrigation"	 Style="TutorialContainer"			Anchor="C,T"	Offset="5, 50" AnchorSide="O,O"  TriggerBy="TutorialSelectEndTurnIrrigation"  >
+			<Grid																																					Style="TutorialEndTurnCalloutGrid"  >
+				<Label																			Style="TutorialEndTurnHeaderText"					String="LOC_META_332_HEAD" />
+				<Label																			Style="TutorialEndTurnBodyText"	String="LOC_META_332_BODY" />
+      </Grid>
+      <SlideAnim																			Start="0,0"		EndOffset="0,-20" Cycle="Bounce" Function="OutQuad" Anchor="C,B">
+        <Image																			Offset="-20,-35"	Size="44,58"		Texture="Tutorial_ArrowV" />
+      </SlideAnim>
+		</Tutorial>
+    <Image						ID="CountImage"							Anchor="R,B"	Offset="15,8" Texture="ActionPanel_TurnBlockerGroup" Hidden="1" >
+      <Label					ID="Count"									Anchor="C,C"	Offset="0,0"	Style="FontFlair18" String="2" />
+    </Image>
+	</Container>
+
+	
+  <!-- INSTANCES -->
+
+  <Instance				Name="TurnBlockerInstance">
+    <GridButton		ID="TurnBlockerButton"																						Size="210,50"	Style="ButtonLightWeight" >
+      <Stack			StackGrowth="Right">
+        <Image																						Size="50,50" Texture="ActionPanel_Notification2">
+          <Image ID="TurnBlockerIcon" Size="40,40" Anchor="C,C" Texture="Notifications40"/>
+        </Image>
+        <Label		ID="TurnBlockerLabel"								Anchor="L,C" WrapWidth="150"	String="LOC_META_331_HEAD"  Style="ActionPanelText" FontStyle="None" />
+      </Stack>
+    </GridButton>
+  </Instance>
+	
+</Context>

--- a/Assets/UI/worldinput.xml
+++ b/Assets/UI/worldinput.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+
+<Context>
+  <Container    ID="DebugStuff"       Anchor="L,T"  Size="100,20"  Offset="0,150" Hidden="1" >
+    <AlphaAnim  ID="a1"                             Size="20,20"  Offset="0,0," AlphaBegin="1" AlphaEnd="0" Speed="2" Cycle="Once">
+      <Box      ID="b1"                             Size="parent,parent" Color="255,50,50,255">
+        <Label  ID="t1"               Anchor="C,C"  FontSize="9" FontStyle="Stroke" Color="255,255,255,255" EffectColor="0,0,0,100" String="-1" />
+      </Box>
+    </AlphaAnim>
+    <AlphaAnim  ID="a2"                             Size="20,20"  Offset="30,0," AlphaBegin="1" AlphaEnd="0" Speed="2" Cycle="Once">
+      <Box      ID="b2"                             Size="parent,parent" Color="50,255,50,255">
+        <Label  ID="t2"               Anchor="C,C"  FontSize="9" FontStyle="Stroke" Color="255,255,255,255" EffectColor="0,0,0,100" String="-1" />
+      </Box>
+    </AlphaAnim>
+    <AlphaAnim  ID="a3"                             Size="20,20"  Offset="60,0," AlphaBegin="1" AlphaEnd="0" Speed="2" Cycle="Once">
+      <Box      ID="b3"                             Size="parent,parent" Color="50,50,255,255">
+        <Label  ID="t3"               Anchor="C,C"  FontSize="9" FontStyle="Stroke" Color="255,255,255,255" EffectColor="0,0,0,100" String="-1" />
+      </Box>
+    </AlphaAnim>
+  </Container>
+	
+  <Container                                        Size="parent,parent">
+    <Container  ID="LeftScreenEdge"    Anchor="L,T" Size="2,parent" Offset="0,0"              />
+    <Container  ID="RightScreenEdge"   Anchor="R,T" Size="2,parent" Offset="0,0"               />
+	<Container  ID="TopScreenEdge"     Anchor="L,T" Size="parent,2" Offset="0,0" />
+    <Container  ID="BottomScreenEdge"  Anchor="L,B" Size="parent,2" Offset="0,0"  />
+  </Container>
+	
+</Context>

--- a/Assets/UI/worldtracker.xml
+++ b/Assets/UI/worldtracker.xml
@@ -9,7 +9,7 @@
 
   <AlphaAnim ID="WorldTrackerAlpha" AlphaBegin="0" AlphaEnd="1" Speed="3" Cycle="Once" Function="OutQuint" Stopped="0">
     <SlideAnim ID="WorldTrackerSlide" Start="0,-100" EndOffset="0,100" Function="OutQuint" Speed="3" Cycle="Once" Stopped="0">
-      <Stack              ID="PanelStack" StackGrowth="Down" Offset="0,75" ConsumeMouseOver="1">
+      <Stack              ID="PanelStack" StackGrowth="Down" Offset="0,75" ConsumeMouseOver="0">
         <Box  ID="WorldTrackerHeader" Color="40,35,25,230" Size="296,auto" AutoSizePadding="0,2">
           <Box Color="143,122,82,200" Anchor="L,B" Size="parent-1,2">
             <Box Color="0,0,0,200" Anchor="L,T" Size="parent-1,1" AnchorSide="I,O"/>
@@ -72,7 +72,7 @@
   <!-- ================================================================== -->
 
   <Instance           Name="ResearchInstance">
-    <Grid             ID="MainPanel"                                Offset="0,0" Size="296,96"          Texture="ResearchPanel_Frame" SliceCorner="80,80" SliceSize="1,1" SliceTextureSize="110,88" ConsumeMouseOver="1">
+    <Grid             ID="MainPanel"                                Offset="0,0" Size="296,96"          Texture="ResearchPanel_Frame" SliceCorner="80,80" SliceSize="1,1" SliceTextureSize="110,88" ConsumeMouseOver="0">
       <Box                                                          Offset="0,25" Size="parent,1"       Color="0,0,0,100"/>
       <Container                                                    Offset="-5,0" Size="parent,parent" >
         <FlipAnim     ID="MainGearAnim"                                                                 Texture="ResearchPanel_MeterFrameAnim" FrameCount="3" Columns="3" Speed="10" Size="40,40" Stopped="1"/>
@@ -99,7 +99,7 @@
   </Instance>
 
   <Instance           Name="CivicInstance">
-    <Grid             ID="MainPanel"                                Offset="0,0"    Size="296,96"         Texture="CivicPanel_Frame" SliceCorner="80,80" SliceSize="1,1" SliceTextureSize="110,88" ConsumeMouseOver="1">
+    <Grid             ID="MainPanel"                                Offset="0,0"    Size="296,96"         Texture="CivicPanel_Frame" SliceCorner="80,80" SliceSize="1,1" SliceTextureSize="110,88" ConsumeMouseOver="0">
       <Box                                                          Offset="0,25"   Size="parent,1"       Color="0,0,0,100"/>
       <Container                                                    Offset="-5,0"   Size="parent,parent" >
         <FlipAnim     ID="MainGearAnim"                                                                   Texture="CivicPanel_MeterFrameAnim" FrameCount="3" Columns="3" Speed="10" Size="40,40" Stopped="1"/>


### PR DESCRIPTION
This fixes the wacky mouse edge scrolling built into civ6.

-Fixes top scrolling so that it actually uses edge of screen, instead of being below top bar.
-Reduces edge scrolling activation zones from 30 to 2 pixels width, this fixes an issue where the scrolling was activated while trying to click on a unit on the map that is close to the edge of the screen.
-Fixes edge scrolling left of WorldTracker.
-Fixes edge scrolling below of UnitPanel when UnitPanel is displayed.
-Fixes edge scrolling below and right of ActionPanel.
-Fixes edge scrolling right of NotificationPanel.

What this patch doesn't fix: Edge scrolling not working right of "top right menu" (menu that includes the overviews buttons for City-States, Trade, Spying, Religion). I have yet to find out how this Panel is called.