### PR TITLE
Patch 1.0.0.216 fixes (#278, #279, #280)

### DIFF
--- a/Assets/UI/Choosers/civicschooser.lua
+++ b/Assets/UI/Choosers/civicschooser.lua
@@ -174,10 +174,13 @@ function AddAvailableCivic( playerID:number, kData:table )
   local extraUnlocks:table = {};
   local hideDescriptionIcon:boolean = false;
   local cachedModifier:table = m_CachedModifiers[kData.CivicType];
-  for _,iconData in pairs(g_ExtraIconData) do
-    if iconData.ModifierType == cachedModifier.ModifierType then
-      hideDescriptionIcon = hideDescriptionIcon or iconData.HideDescriptionIcon;
-      table.insert(extraUnlocks, iconData);
+  if ( cachedModifiers ) then
+    for _,tModifier in ipairs(cachedModifiers) do
+      local tIconData :table = g_ExtraIconData[tModifier.ModifierType];
+      if ( tIconData ) then
+        hideDescriptionIcon = hideDescriptionIcon or tIconData.HideDescriptionIcon;
+        table.insert(extraUnlocks, {IconData=tIconData, ModifierTable=tModifier});
+      end
     end
   end
   
@@ -186,8 +189,8 @@ function AddAvailableCivic( playerID:number, kData:table )
   numUnlockables = PopulateUnlockablesForCivic( playerID, kData.ID, unlockIM, nil, callback, hideDescriptionIcon );
   
   -- Initialize extra icons
-  for _,iconData in pairs(extraUnlocks) do
-    iconData:Initialize(kItemInstance.UnlockStack, cachedModifier);
+  for _,tUnlock in pairs(extraUnlocks) do
+    tUnlock.IconData:Initialize(kItemInstance.UnlockStack, tUnlock.ModifierTable);
     numUnlockables = numUnlockables + 1;
   end
   

--- a/Assets/UI/Popups/mappinpopup.lua
+++ b/Assets/UI/Popups/mappinpopup.lua
@@ -392,12 +392,12 @@ end
 -- Event Handlers
 ----------------------------------------------------------------
 function OnMapPinPlayerInfoChanged( playerID :number )
-  PlayerTarget_OnPlayerInfoChanged( playerID, Controls.VisibilityPull, nil, g_visibilityTargetEntries, g_playerTarget, true);
+  PlayerTarget_OnPlayerInfoChanged( playerID, Controls.VisibilityPull, nil, nil, g_visibilityTargetEntries, g_playerTarget, true);
 end
 
 function OnLocalPlayerChanged()
   g_playerTarget.targetID = Game.GetLocalPlayer();
-  PopulateTargetPull(Controls.VisibilityPull, nil, g_visibilityTargetEntries, g_playerTarget, true, OnVisibilityPull);
+  PopulateTargetPull(Controls.VisibilityPull, nil, nil, g_visibilityTargetEntries, g_playerTarget, true, OnVisibilityPull);
 
   if( not ContextPtr:IsHidden() ) then
     UIManager:DequeuePopup( ContextPtr );
@@ -434,7 +434,7 @@ function Initialize()
   ContextPtr:SetInputHandler( OnInputHandler, true );
 
   PopulateIconOptions();
-  PopulateTargetPull(Controls.VisibilityPull, nil, g_visibilityTargetEntries, g_playerTarget, true, OnVisibilityPull);
+  PopulateTargetPull(Controls.VisibilityPull, nil, nil, g_visibilityTargetEntries, g_playerTarget, true, OnVisibilityPull);
   Controls.DeleteButton:RegisterCallback(Mouse.eLClick, OnDelete);
   Controls.DeleteButton:RegisterCallback( Mouse.eMouseEnter, function() UI.PlaySound("Main_Menu_Mouse_Over"); end);
   Controls.SendToChatButton:RegisterCallback(Mouse.eLClick, OnSendToChatButton);

--- a/Assets/UI/Screens/civicstree.lua
+++ b/Assets/UI/Screens/civicstree.lua
@@ -465,13 +465,16 @@ function AllocateUI()
     -- end
 
 		-- Include extra icons in total unlocks
-		for _,iconData in pairs(g_ExtraIconData) do
-			if iconData.ModifierType == item.ModifierType then
-				numUnlocks = numUnlocks + 1;
-				hideDescriptionIcon = hideDescriptionIcon or iconData.HideDescriptionIcon;
-				table.insert(extraUnlocks, iconData);
-			end
-		end
+    if ( item.ModifierList ) then
+      for _,tModifier in ipairs(item.ModifierList) do
+        local tIconData :table = g_ExtraIconData[tModifier.ModifierType];
+        if ( tIconData ) then
+          numUnlocks = numUnlocks + 1;
+          hideDescriptionIcon = hideDescriptionIcon or tIconData.HideDescriptionIcon;
+          table.insert(extraUnlocks, {IconData=tIconData, ModifierTable=tModifier});
+        end
+      end
+    end
 
     -- Create node based on # of unlocks for this civic.
     if numUnlocks <= 8 then
@@ -523,9 +526,8 @@ function AllocateUI()
 		-- end
 
 		-- Initialize extra icons
-		for _,iconData in pairs(extraUnlocks) do
-			iconData:Initialize(node.UnlockStack, item);
-			-- extraIconDataCache[iconData.Context.CData] = item;
+    for _,tUnlock in pairs(extraUnlocks) do
+      tUnlock.IconData:Initialize(node.UnlockStack, tUnlock.ModifierTable);
     end
 
     -- What happens when clicked

--- a/Assets/UI/techandcivicsupport.lua
+++ b/Assets/UI/techandcivicsupport.lua
@@ -732,19 +732,22 @@ function RealizeCurrentCivic( playerID:number, kData:table, kControl:table, cach
     -- Include extra icons in total unlocks
     local extraUnlocks:table = {};
     local hideDescriptionIcon:boolean = false;
-    local cachedModifier:table = cachedModifiers[kData.CivicType];
-    for _,iconData in pairs(g_ExtraIconData) do
-      if iconData.ModifierType == cachedModifier.ModifierType then
-        hideDescriptionIcon = hideDescriptionIcon or iconData.HideDescriptionIcon;
-        table.insert(extraUnlocks, iconData);
+    local civicModifiers:table = cachedModifiers[kData.CivicType];
+    if ( civicModifiers ) then
+      for _,tModifier in ipairs(civicModifiers) do
+        local tIconData :table = g_ExtraIconData[tModifier.ModifierType];
+        if ( tIconData ) then
+          hideDescriptionIcon = hideDescriptionIcon or tIconData.HideDescriptionIcon;
+          table.insert(extraUnlocks, {IconData=tIconData, ModifierTable=tModifier});
+        end
       end
     end
     
     numUnlockables = PopulateUnlockablesForCivic( playerID, kData.ID, techUnlockIM, nil, nil, hideDescriptionIcon );
     
     -- Initialize extra icons
-    for _,iconData in pairs(extraUnlocks) do
-      iconData:Initialize(kControl.UnlockStack, cachedModifier);
+    for _,tUnlock in pairs(extraUnlocks) do
+      tUnlock.IconData:Initialize(kControl.UnlockStack, tUnlock.ModifierTable);
       numUnlockables = numUnlockables + 1;
     end
     

--- a/Assets/UI/worldinput.lua
+++ b/Assets/UI/worldinput.lua
@@ -3791,14 +3791,14 @@ function Initialize()
 
 
   -- UI Events
-  Controls.LeftScreenEdge:RegisterMouseEnterCallback( OnMouseBeginPanLeft );
-  Controls.LeftScreenEdge:RegisterMouseExitCallback( OnMouseStopPanLeft );
-  Controls.RightScreenEdge:RegisterMouseEnterCallback( OnMouseBeginPanRight );
-  Controls.RightScreenEdge:RegisterMouseExitCallback( OnMouseStopPanRight );
-  Controls.TopScreenEdge:RegisterMouseEnterCallback( OnMouseBeginPanUp );
-  Controls.TopScreenEdge:RegisterMouseExitCallback( OnMouseStopPanUp );
-  Controls.BottomScreenEdge:RegisterMouseEnterCallback( OnMouseBeginPanDown );
-  Controls.BottomScreenEdge:RegisterMouseExitCallback( OnMouseStopPanDown );
+  -- Controls.LeftScreenEdge:RegisterMouseEnterCallback( OnMouseBeginPanLeft );
+  -- Controls.LeftScreenEdge:RegisterMouseExitCallback( OnMouseStopPanLeft );
+  -- Controls.RightScreenEdge:RegisterMouseEnterCallback( OnMouseBeginPanRight );
+  -- Controls.RightScreenEdge:RegisterMouseExitCallback( OnMouseStopPanRight );
+  -- Controls.TopScreenEdge:RegisterMouseEnterCallback( OnMouseBeginPanUp );
+  -- Controls.TopScreenEdge:RegisterMouseExitCallback( OnMouseStopPanUp );
+  -- Controls.BottomScreenEdge:RegisterMouseEnterCallback( OnMouseBeginPanDown );
+  -- Controls.BottomScreenEdge:RegisterMouseExitCallback( OnMouseStopPanDown );
   ContextPtr:SetInputHandler( OnInputHandler, true );
   ContextPtr:SetRefreshHandler( OnRefresh );
   ContextPtr:SetAppRegainedFocusHandler( OnAppRegainedFocusHandler );


### PR DESCRIPTION
Fixes issues #278, #279, and #280 - which were all introduced in the latest patch for the base game.

**Note:** In order to solve issue #278, I had to comment out the mouse enter/exit callbacks registered at the end of the `worldinput.lua` file. The controls for which those callbacks are registered are not found in the `WorldInput.xml` file included with the game, and the repository does not seem to include a modified version of the file with those elements either. Did the pre-patch game file include those controls? I found that a bit strange, so I decided not to include any related changes (asides from commenting out the callback registrations). Hopefully somebody with more experience can explain that to me.