### PR TITLE
Patch ML 1.0.0.216

### DIFF
--- a/Assets/UI/Panels/citypanel.lua
+++ b/Assets/UI/Panels/citypanel.lua
@@ -103,6 +103,7 @@ function CQUI_OnCityviewEnabled()
     UI.SetFixedTiltMode(true);
     DisplayGrowthTile();
     UI.SetInterfaceMode(InterfaceModeTypes.CITY_MANAGEMENT);
+
 end
 
 function CQUI_OnCityviewDisabled()
@@ -1048,7 +1049,7 @@ function OnUnitSelectionChanged( playerID:number, unitID:number, hexI:number, he
   if playerID == Game.GetLocalPlayer() then
     if ContextPtr:IsHidden()==false then
       Close();
-      Controls.ToggleOverviewPanel:SetAndCall(false); 
+      Controls.ToggleOverviewPanel:SetAndCall(false);
     end
   end
 end
@@ -1498,7 +1499,7 @@ function Initialize()
   LuaEvents.CityPanel_ToggleManageCitizens.Add(function()
     Controls.ManageCitizensCheck:SetAndCall(not Controls.ManageCitizensCheck:IsChecked());
   end);
-  
+
   -- CQUI Events
   LuaEvents.CQUI_GoNextCity.Add( CQUI_OnNextCity );
   LuaEvents.CQUI_GoPrevCity.Add( CQUI_OnPreviousCity );

--- a/Assets/UI/Panels/citypaneloverview.lua
+++ b/Assets/UI/Panels/citypaneloverview.lua
@@ -113,6 +113,7 @@ function SetDesiredLens(desiredLens)
   m_desiredLens = desiredLens;
   -- AZURENCY : don't change interface mode
   --UI.SetInterfaceMode(InterfaceModeTypes.SELECTION);
+  --[[
   if m_isShowingPanel then
     if m_desiredLens == "CityManagement" then
       LuaEvents.Area_RefreshCitizenManagement(m_pCity:GetID());
@@ -122,7 +123,10 @@ function SetDesiredLens(desiredLens)
   else
     UILens.SetActive(m_desiredLens);
   end
+  ]]
+  UILens.SetActive(m_desiredLens);
 end
+
 function EnsureDesiredLens()
   if m_isShowingPanel then
     if m_desiredLens == "CityManagement" then
@@ -285,7 +289,7 @@ function ViewPanelBreakdown( data:table )
   end
 
   -- Add trading posts
-  local hideTradingPostsInfo :boolean = not GameCapabilities.HasCapability("CAPABILITY_CITY_HUD_TRADING_POSTS");  
+  local hideTradingPostsInfo :boolean = not GameCapabilities.HasCapability("CAPABILITY_CITY_HUD_TRADING_POSTS");
   local isHasTradingPosts :boolean = (table.count(data.TradingPosts) > 0)
   Controls.NoTradingPostsArea:SetHide(hideTradingPostsInfo or isHasTradingPosts);
   Controls.TradingPostsArea:SetHide(hideTradingPostsInfo or not isHasTradingPosts);
@@ -305,7 +309,7 @@ function ViewPanelBreakdown( data:table )
         -- If we're a city-state display our city-state icon instead of leader since we don't have one
         local leader:string = pTradePostPlayerConfig:GetLeaderTypeName();
         local civType:string = GameInfo.CivilizationLeaders[leader].CivilizationType;
-        local primaryColor, secondaryColor = UI.GetPlayerColors(tradePostPlayerId);	
+        local primaryColor, secondaryColor = UI.GetPlayerColors(tradePostPlayerId);
         iconName = "ICON_"..civType;
         iconColor = secondaryColor;
         iconSize = SIZE_CITYSTATE_ICON;
@@ -377,7 +381,7 @@ function ViewPanelReligion( data:table )
     end
 
     -- Other religions
-    for _,religion in ipairs(data.Religions) do		
+    for _,religion in ipairs(data.Religions) do
       -- Don't show pantheons or dominate religions here. Dominate religion is handled above.
       if religion.ReligionType ~= "RELIGION_PANTHEON" and (dominateReligion == nil or religion.ReligionType ~= dominateReligion.ReligionType) then
         local religionName	:string = Game.GetReligion():GetName(religion.ID);
@@ -385,7 +389,7 @@ function ViewPanelReligion( data:table )
         local textureOffsetX:number, textureOffsetY:number, textureSheet:string = IconManager:FindIconAtlas(iconName, 22);
 
         if textureSheet ~= nil then
-          local religionInstance:table = m_kOtherReligionsIM:GetInstance();	
+          local religionInstance:table = m_kOtherReligionsIM:GetInstance();
           religionInstance.ReligionSymbol:SetTexture( textureSheet );
           religionInstance.ReligionSymbol:SetTextureOffsetVal( textureOffsetX, textureOffsetY );
           religionInstance.ReligionName:SetText( Locale.Lookup("LOC_HUD_CITY_RELIGIOUS_CITIZENS_NUMBER",religion.Followers,religionName) );
@@ -395,7 +399,7 @@ function ViewPanelReligion( data:table )
       end
     end
   end
-  
+
   if Controls.PanelReligion:IsVisible() then
     SetDesiredLens("Religion");
   end
@@ -772,7 +776,7 @@ function PopulateTabs()
     else
       Controls.ReligionButton:SetHide(true);
     end
-    
+
     m_tabs.CenterAlignTabs(0);
   end
   m_tabs.SelectTab( Controls.HealthButton );

--- a/Assets/UI/WorldView/citybannermanager.lua
+++ b/Assets/UI/WorldView/citybannermanager.lua
@@ -3351,6 +3351,11 @@ function OnInterfaceModeChanged( oldMode:number, newMode:number )
       end
     end
   end
+
+  if (UI.GetInterfaceMode() == InterfaceModeTypes.DISTRICT_PLACEMENT) then
+    CQUI_CityManageAreaShown = false
+    CQUI_CityManageAreaShouldShow = false
+  end
 end
 
 -- ===========================================================================

--- a/Assets/UI/WorldView/citybannermanager.lua
+++ b/Assets/UI/WorldView/citybannermanager.lua
@@ -3352,7 +3352,7 @@ function OnInterfaceModeChanged( oldMode:number, newMode:number )
     end
   end
 
-  if (UI.GetInterfaceMode() == InterfaceModeTypes.DISTRICT_PLACEMENT) then
+  if (newMode == InterfaceModeTypes.DISTRICT_PLACEMENT) then
     CQUI_CityManageAreaShown = false
     CQUI_CityManageAreaShouldShow = false
   end

--- a/Assets/UI/worldinput.lua
+++ b/Assets/UI/worldinput.lua
@@ -2405,7 +2405,7 @@ function CoastalRaid( pInputStruct )
     end
 
     if (bWillStartWar) then
-      -- Create the action specific parameters 
+      -- Create the action specific parameters
       LuaEvents.WorldInput_ConfirmWarDialog(pSelectedUnit:GetOwner(), results, WarTypes.SURPRISE_WAR);
     else
       if (UnitManager.CanStartOperation( pSelectedUnit, UnitOperationTypes.COASTAL_RAID, nil, tParameters)) then
@@ -3096,14 +3096,14 @@ function OnCycleUnitSelectionRequest()
 
   if(UI.GetInterfaceMode() ~= InterfaceModeTypes.NATURAL_WONDER or m_isMouseButtonRDown) then
 
-    -- AZURENCY : OnCycleUnitSelectionRequest is called by UI.SetCycleAdvanceTimer() 
-    -- in SelectedUnit.lua causing a conflict with the auto-cyling of unit 
+    -- AZURENCY : OnCycleUnitSelectionRequest is called by UI.SetCycleAdvanceTimer()
+    -- in SelectedUnit.lua causing a conflict with the auto-cyling of unit
     -- (not the same given by UI.SelectNextReadyUnit() and player:GetUnits():GetFirstReadyUnit())
     local pPlayer :table = Players[Game.GetLocalPlayer()];
     if pPlayer ~= nil then
       if pPlayer:IsTurnActive() then
         local unit:table = pPlayer:GetUnits():GetFirstReadyUnit();
-        -- AZURENCY : we also check if there is not already a unit selected, 
+        -- AZURENCY : we also check if there is not already a unit selected,
         -- bacause UI.SetCycleAdvanceTimer() is always called after deselecting a unit
         if unit ~= nil and not UI.GetHeadSelectedUnit() then
           UI.DeselectAllUnits();

--- a/Assets/cqui_settings.sql
+++ b/Assets/cqui_settings.sql
@@ -41,7 +41,7 @@ INSERT OR REPLACE INTO CQUI_Settings -- Don't touch this line!
       ("CQUI_BlockOnCityAttack", 1), -- Block turn from ending if you have a city that can attack
       ("CQUI_ProductionQueue", 1), -- A production queue appears next to the production panel, allowing multiple constructions to be queued at once
       ("CQUI_ShowCultureGrowth", 1), -- Shows cultural growth overlay in cityview
-      ("CQUI_ShowPolicyReminder", 1), 
+      ("CQUI_ShowPolicyReminder", 1),
 	  ("CQUI_ShowLuxuries", 1), -- Luxury resources will show in the top-bar next to strategic resources
       ("CQUI_ShowUnitPaths", 1), -- Shows unit paths on hover and selection
       ("CQUI_ShowYieldsOnCityHover", 1), -- Shows city management info like citizens, tile yields, and tile growth on hover
@@ -93,8 +93,7 @@ INSERT OR REPLACE INTO CQUI_Settings -- Don't touch this line!
 */
 
 INSERT OR REPLACE INTO CQUI_Settings -- Don't touch this line!
-  VALUES  ("CQUI_MinimapSize", 100), -- Factor used for setting minimap size. (between 0 and 100).
-  ("CQUI_ProductionItemHeight", 32), -- Height used for individual items in the production queue. Recommended values fall between 24 and 128, though any positive could work
+  VALUES  ("CQUI_ProductionItemHeight", 32), -- Height used for individual items in the production queue. Recommended values fall between 24 and 128, though any positive could work
   ("CQUI_SmartWorkIconSize", 64), -- Size used for "smart" work icons. This size is applied to work icons that are currently locked if the smart work icon option is enabled. Recommended values fall between 48 and 128, though any positive multiple of 8 could work (non-multiples are rounded down)
   ("CQUI_SmartWorkIconAlpha", 40), -- Transparency percent used for "smart" work icons. This alpha is applied to work icons that are currently locked if the smart work icon option is enabled. Recommended values fall between 10 and 100, though any value between 0 and 100 could work
   ("CQUI_WorkIconSize", 64), -- Size used for work icons. Applies to all icons that aren't flagged using the "smart" work icon feature. Recommended values fall between 48 and 128, though any positive multiple of 8 could work (non-multiples are rounded down)

--- a/Assets/cqui_settingselement.lua
+++ b/Assets/cqui_settingselement.lua
@@ -224,20 +224,6 @@ local ProductionItemHeightConverter = {
   end
 };
 
---Minimum value is 224, maximum is 768, but only multiples of 8 are allowed. This translates to 68 steps, or 0th step to the 67th
-local MinimapSizeConverter = {
-  ToSteps = function(value)
-    local out = value;
-    if(out < 0) then out = 0; end
-    return out;
-  end,
-  ToValue = function(steps)
-    local out = steps;
-    if(out > 100) then out = 100; end
-    return out;
-  end
-};
-
 --Minimum value is 48, maximum is 128, but only multiples of 8 are allowed. This translates to 10 steps, or 0th step to the 9th
 local WorkIconSizeConverter = {
   ToSteps = function(value)
@@ -346,7 +332,6 @@ function Initialize()
   PopulateCheckBox(Controls.SmartWorkIconCheckbox, "CQUI_SmartWorkIcon", Locale.Lookup("LOC_CQUI_CITYVIEW_SMARTWORKICON_TOOLTIP"));
   PopulateCheckBox(Controls.ShowPolicyReminderCheckbox, "CQUI_ShowPolicyReminder", Locale.Lookup("LOC_CQUI_GENERAL_SHOWPRD_TOOLTIP"));
   PopulateSlider(Controls.ProductionItemHeightSlider, Controls.ProductionItemHeightText, "CQUI_ProductionItemHeight", ProductionItemHeightConverter);
-  PopulateSlider(Controls.MinimapSizeSlider, Controls.MinimapSizeText, "CQUI_MinimapSize", MinimapSizeConverter);
   PopulateSlider(Controls.WorkIconSizeSlider, Controls.WorkIconSizeText, "CQUI_WorkIconSize", WorkIconSizeConverter);
   PopulateSlider(Controls.SmartWorkIconSizeSlider, Controls.SmartWorkIconSizeText, "CQUI_SmartWorkIconSize", WorkIconSizeConverter);
   PopulateSlider(Controls.WorkIconAlphaSlider, Controls.WorkIconAlphaText, "CQUI_WorkIconAlpha", WorkIconAlphaConverter);

--- a/Assets/cqui_settingselement.xml
+++ b/Assets/cqui_settingselement.xml
@@ -47,13 +47,6 @@
           <Stack Anchor="R,T" StackGrowth="Left" Padding="5">
             <GridButton ID="ToggleYieldsOnLoadCheckbox" Anchor="L,C" Offset="0,0" Size="300,24" Style="CheckBoxControl" String="LOC_CQUI_GENERAL_TOGGLEYIELDSONLOAD" />
           </Stack>
-          <Grid Size="0,35" Anchor="R,T" AutoSize="H" Color="0,0,0,0">
-            <Stack Anchor="C,T" StackGrowth="Left" Padding="3">
-              <Label String="777" Style="ShellOptionText" Anchor="L,C" ID="MinimapSizeText" Hidden="1"/>
-              <Label Style="ShellOptionText" String="LOC_CQUI_GENERAL_MINIMAPSIZE"/>
-            </Stack>
-            <Slider Style="SliderControl" Anchor="C,B" Size="300,13" SpaceForScroll="0" ID="MinimapSizeSlider" Steps="100" />
-          </Grid>
         </Stack>
       </Container>
       <Container ID="PopupsOptions" Size="parent,parent" Hidden="1">

--- a/CQUI.modinfo
+++ b/CQUI.modinfo
@@ -9,7 +9,7 @@
     <Description>Community Quick User Interface MOD was Formally CQUI Mod [NEWLINE]and is now being updated and improved by its community</Description>
   </Properties>
 
-  <!--Incompatible mods.-->  
+  <!--Incompatible mods.-->
   <Blocks>
     <Mod id="9e9923e5-6842-4e7d-97e7-c9a56a85cf03" title="Simplified Gossip" />
     <Mod id="37b5fdca-2690-96ff-ea23-d8612ae7a757" title="Divine Yuri's Custom City Panel" />
@@ -19,7 +19,7 @@
     <Mod id="35f33319-ad93-4d6b-bf27-406fac382d06" title="More Lenses" />
     <Mod id="c9d28cde-61ee-459c-93f5-c734cd392553" title="NQ Enhanced User Interface" />
   </Blocks>
-  
+
   <!-- Modinfo Specific LOC -->
   <LocalizedText>
     <Text id="CQUI_TEASER">
@@ -299,7 +299,7 @@
         <File>Assets/UI/WorldView/plotinfo.xml</File>
       </Items>
     </ImportFiles>
-	
+
     <!-- CQUI specific LOCs  -->
     <LocalizedText id="CQUI_TEXT">
       <Items>
@@ -333,7 +333,7 @@
         <File>Assets/Text/cqui_text_settings_zh.xml</File>
       </Items>
     </LocalizedText>
-	
+
     <!-- CQUI specific settings -->
     <UpdateDatabase id="CQUI_Settings">
       <Properties>
@@ -345,7 +345,7 @@
         <File>Assets/cqui_settings_local.sql</File>
       </Items>
     </UpdateDatabase>
-	
+
     <!-- CQUI specific UIs -->
     <UserInterface id="CQUI_UI">
       <Properties>
@@ -358,21 +358,21 @@
         <!--the lua files are taken as implied-->
       </Items>
     </UserInterface>
-	
+
     <!-- CQUI specific scripts -->
     <GameplayScripts id="CQUI_SCRIPTS">
       <Items>
         <File>Assets/cqui_main.lua</File>
       </Items>
     </GameplayScripts>
-	
+
     <!-- CQUI specific art overrides -->
     <ModArt id="CQUI_MODART">
       <Items>
         <File>cqui.dep</File>
       </Items>
     </ModArt>
-    
+
     <!-- Mod integrations -->
     <LocalizedText id="BTS_TEXT">
       <Items>
@@ -464,8 +464,15 @@
       </Items>
     </LocalizedText>
     <ImportFiles id="MORELENSES_LENSES">
+      <Properties>
+        <LoadOrder>0</LoadOrder>
+        <Context>InGame</Context>
+      </Properties>
       <Items>
-        <File>Integrations/ML/UI/lenssupport.lua</File>
+        <!-- Support file first -->
+        <File Priority="1">Integrations/ML/UI/lenssupport.lua</File>
+
+        <!-- All Lenses later -->
         <File>Integrations/ML/UI/Lenses/modlens_builder.lua</File>
         <File>Integrations/ML/UI/Lenses/modlens_scout.lua</File>
         <File>Integrations/ML/UI/Lenses/modlens_archaeologist.lua</File>
@@ -475,15 +482,28 @@
         <File>Integrations/ML/UI/Lenses/modlens_wonder.lua</File>
       </Items>
     </ImportFiles>
+    <AddUserInterfaces id="MORELENSES_LENSES_WPANEL">
+      <Properties>
+        <Context>InGame</Context>
+        <LoadOrder>1</LoadOrder>
+      </Properties>
+      <Items>
+        <File>Integrations/ML/UI/Lenses/modlens_cityoverlap.xml</File>
+        <!-- ModLens_CityOverlap.lua implied -->
+        <File>Integrations/ML/UI/Lenses/modlens_resource.xml</File>
+        <!-- ModLens_Resource.lua implied -->
+      </Items>
+    </AddUserInterfaces>
     <ImportFiles id="MORELENSES_IMPORT_FILES">
+      <!-- ML replacements after all lens files imported -->
+      <Properties>
+        <LoadOrder>2</LoadOrder>
+      </Properties>
       <Items>
         <File>Integrations/ML/UI/minimappanel.lua</File>
         <File>Integrations/ML/UI/minimappanel.xml</File>
         <File>Integrations/ML/UI/Panels/modallenspanel.lua</File>
         <File>Integrations/ML/UI/Panels/modallenspanel.xml</File>
-        <File>Integrations/ML/UI/Lenses/modlens_cityoverlap.xml</File>
-        <!-- ModLens_CityOverlap.lua implied -->
-        <File>Integrations/ML/UI/Lenses/modlens_resource.xml</File>
       </Items>
     </ImportFiles>
     <LocalizedText id="MORELENSES_TEXT">

--- a/Integrations/ML/UI/Panels/modallenspanel.lua
+++ b/Integrations/ML/UI/Panels/modallenspanel.lua
@@ -260,13 +260,12 @@ function OnLensLayerOn( layerNum:number )
   elseif layerNum == LensLayers.HEX_COLORING_APPEAL_LEVEL then
     -- Check for mod lens
     local lens = {}
-    local lens = {}
     LuaEvents.MinimapPanel_GetActiveModLens(lens)
     if lens ~= nil and lens[1] ~= "NONE" then
       if lens[1] == "VANILLA_APPEAL" then
         Controls.LensText:SetText(Locale.ToUpper(Locale.Lookup("LOC_HUD_APPEAL_LENS")));
         ShowAppealLensKey();
-      else
+      elseif lens[1] ~= "ML_CUSTOM" and lens[1] ~= "NONE" then
         ShowModLensKey(lens[1])
       end
     end

--- a/Integrations/ML/UI/Panels/modallenspanel.lua
+++ b/Integrations/ML/UI/Panels/modallenspanel.lua
@@ -1,6 +1,7 @@
 -- Provides info about currently active Modal Lens
 
 include( "InstanceManager" );
+include( "Civ6Common" );
 
 -- ===========================================================================
 --  MODDED LENS
@@ -173,7 +174,7 @@ end
 --============================================================================
 function ShowModLensKey(lensName:string)
   -- This is printed even if the modal panel is hidden
-  print("Showing " .. lensName .. " modal panel")
+  print_debug("Showing " .. lensName .. " modal panel")
 
   m_KeyStackIM: ResetInstances();
 

--- a/Integrations/ML/UI/minimappanel.lua
+++ b/Integrations/ML/UI/minimappanel.lua
@@ -23,18 +23,6 @@ local MINIMAP_COLLAPSED_OFFSETY     :number = -180;
 local LENS_PANEL_OFFSET             :number = 50;
 local MINIMAP_BACKING_PADDING_SIZEY :number = 54;
 
--- Different from above, since it uses a government lens, instead of appeal
-local AREA_LENS_ID:table = {
-  NONE = 0;
-  GOVERNMENT = 1;
-  CITIZEN_MANAGEMENT = 2;
-}
-
--- Show citizen management when managing citizens
-local SHOW_CITIZEN_MANAGEMENT_INSCREEN:boolean = true;
-
-local CITY_WORK_RANGE:number = 3;
-
 -- ===========================================================================
 --  GLOBALS
 -- ===========================================================================
@@ -75,24 +63,6 @@ local m_isMouseDragEnabled      :boolean = true; -- Can the camera be moved by d
 local m_isMouseDragging         :boolean = false; -- Was LMB clicked inside the minimap, and has not been released yet?
 local m_hasMouseDragged         :boolean = false; -- Has there been any movements since m_isMouseDragging became true?
 local m_wasMouseInMinimap       :boolean = false; -- Was the mouse over the minimap the last time we checked?
-
-local m_CurrentAreaLensOn       :number  = AREA_LENS_ID.NONE;
-
--- Resource Lens Specific Vars
-local ResourcesToHide:table = {};
-local ResourceCategoryToHide:table = {};
-
-local m_CityOverlapRange:number = 6;
-
-local m_CurrentCursorPlotID:number = -1;
-
--- Citizen management lens variables
-local m_CitizenManagementOn:boolean = false;
-local m_FullClearAreaLens:boolean = true;
-local m_tAreaPlotsColored:table = {}
-
--- Settler Lens Variables
-local m_CtrlDown:boolean = false;
 
 local CQUI_MapSize = 512;
 local CQUI_MapImageScaler = 0.5;
@@ -258,6 +228,7 @@ function OnToggleLensList()
     Controls.GovernmentLensButton:SetHide(not GameCapabilities.HasCapability("CAPABILITY_LENS_GOVERNMENT"));
     Controls.WaterLensButton:SetHide(not GameCapabilities.HasCapability("CAPABILITY_LENS_SETTLER"));
     Controls.TourismLensButton:SetHide(not GameCapabilities.HasCapability("CAPABILITY_LENS_TOURISM"));
+    Controls.LensToggleStack:CalculateSize();
     -- Controls.LensPanel:SetSizeY(Controls.LensToggleStack:GetSizeY() + LENS_PANEL_OFFSET);
   end
 end
@@ -271,7 +242,7 @@ function CloseLensList()
   Controls.WaterLensButton:SetCheck(false);
   Controls.OwnerLensButton:SetCheck(false);
   Controls.TourismLensButton:SetCheck(false);
-  
+
   -- Turn off each mod lens
   local i = 1
   local lensButtonInstance = m_LensButtonIM:GetAllocatedInstance(i)
@@ -280,10 +251,10 @@ function CloseLensList()
     i = i + 1
     lensButtonInstance = m_LensButtonIM:GetAllocatedInstance(i)
   end
-  
+
   -- Hide each panel that exist for lens
   LuaEvents.ML_CloseLensPanels()
-  
+
   if UI.GetInterfaceMode() == InterfaceModeTypes.VIEW_MODAL_LENS then
     UI.SetInterfaceMode(InterfaceModeTypes.SELECTION);
   end
@@ -376,14 +347,6 @@ end
 -- ===========================================================================
 function ToggleGovernmentLens()
   if Controls.GovernmentLensButton:IsChecked() then
-    SetActiveAreaLens(AREA_LENS_ID.GOVERNMENT);
-
-    -- Check if the gov lens is already active. Needed to clear any gov lens
-    if UILens.IsLayerOn(LensLayers.HEX_COLORING_GOVERNMENT) then
-      -- Unapply the appeal lens, so it can be cleared from the screen
-      UILens.SetActive("Default");
-    end
-
     UILens.SetActive("Government");
     RefreshInterfaceMode();
   else
@@ -391,7 +354,6 @@ function ToggleGovernmentLens()
     if UI.GetInterfaceMode() == InterfaceModeTypes.VIEW_MODAL_LENS then
       UI.SetInterfaceMode(InterfaceModeTypes.SELECTION);
     end
-    SetActiveAreaLens(AREA_LENS_ID.NONE);
   end
 end
 
@@ -526,11 +488,12 @@ end
 
 -- ===========================================================================
 function OnLensLayerOff( layerNum:number )
-  if (layerNum == LensLayers.HEX_COLORING_RELIGION or 
+  if (layerNum == LensLayers.HEX_COLORING_RELIGION or
       layerNum == LensLayers.HEX_COLORING_CONTINENT or
       layerNum == LensLayers.HEX_COLORING_GOVERNMENT or
       layerNum == LensLayers.HEX_COLORING_OWING_CIV) then
     UI.PlaySound("UI_Lens_Overlay_Off");
+
   -- Clear Modded Lens (Appeal lens included)
   elseif layerNum == LensLayers.HEX_COLORING_APPEAL_LEVEL then
     UILens.ClearLayerHexes( LensLayers.MAP_HEX_MASK );
@@ -538,6 +501,7 @@ function OnLensLayerOff( layerNum:number )
       UILens.ClearLayerHexes(LensLayers.HEX_COLORING_APPEAL_LEVEL);
     end
     UI.PlaySound("UI_Lens_Overlay_Off");
+
   elseif layerNum == LensLayers.HEX_COLORING_WATER_AVAILABLITY then
     -- Only clear the water lens if we're turning off lenses altogether, but not if switching to another modal lens (Turning on another modal lens clears it already).
     if UI.GetInterfaceMode() ~= InterfaceModeTypes.VIEW_MODAL_LENS or (UI.GetHeadSelectedUnit() == nil) then
@@ -587,7 +551,7 @@ function SetOwingCivHexes()
       local primaryColor, secondaryColor = UI.GetPlayerColors( player:GetID() );
 
       for _, pCity in cities:Members() do
-        local plots  :table = Map.GetCityPlots():GetPurchasedPlots(pCity);
+        local plots :table = Map.GetCityPlots():GetPurchasedPlots(pCity);
 
         if(table.count(plots) > 0) then
           UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_OWING_CIV, localPlayer, plots, primaryColor );
@@ -823,113 +787,19 @@ function SetContinentHexes()
   end
 end
 
--- CQUI : Citizen Management
-function SetActiveAreaLens(lensID)
-  m_CurrentAreaLensOn = lensID;
-  LuaEvents.MinimapPanel_AreaLensOn(lensID);
-end
-
-function ClearAreaLens()
-  print_debug("Clearing area lens")
-
-  -- Because of engine limitations, clear previous color of tiles
-  local neutralColor:number = UI.GetColorValue("COLOR_AREA_LENS_NEUTRAL");
-  local localPlayer:number = Game.GetLocalPlayer();
-
-  if m_FullClearAreaLens then
-    local players = Game.GetPlayers();
-    for _, player in ipairs(players) do
-      local cities = player:GetCities();
-      for _, pCity in cities:Members() do
-        local visibleCityPlots:table = Map.GetCityPlots():GetVisiblePurchasedPlots(pCity);
-        if #visibleCityPlots > 0 then
-          UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_GOVERNMENT, localPlayer, visibleCityPlots, neutralColor );
-        end
-      end
-    end
-  elseif (table.count(m_tAreaPlotsColored) > 0) then
-    UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_GOVERNMENT, localPlayer, m_tAreaPlotsColored, neutralColor );
-    m_tAreaPlotsColored = {}
-  end
-
-  UILens.ClearLayerHexes( LensLayers.HEX_COLORING_GOVERNMENT );
-  if UILens.IsLayerOn( LensLayers.HEX_COLORING_GOVERNMENT ) then
-    UILens.ToggleLayerOff( LensLayers.HEX_COLORING_GOVERNMENT );
-  end
-
-  SetActiveAreaLens(AREA_LENS_ID.NONE);
-
-  m_FullClearAreaLens = false;
-end
-
 -- ===========================================================================
-function ShowCitizenManagementArea(cityID)
-  print_debug("Showing city manage area for " .. cityID)
-  SetActiveAreaLens(AREA_LENS_ID.CITIZEN_MANAGEMENT)
-
-  local pCity:table;
-  local localPlayer = Game.GetLocalPlayer()
-
-  if (cityID ~= nil) then
-    pCity = Players[localPlayer]:GetCities():FindID(cityID);
-  else
-    local pPlot = Map.GetPlotByIndex(m_CurrentCursorPlotID)
-    if pPlot:IsCity() and pPlot:GetOwner() == Game.GetLocalPlayer() then
-      pCity = CityManager.GetCityAt(pPlot:GetX(), pPlot:GetY());
-    end
+--  Support function for Hotkey Event
+-- ===========================================================================
+function LensPanelHotkeyControl( pControl:table )
+  if Controls.LensPanel:IsHidden() then
+    Controls.LensPanel:SetHide(false);
+    RealizeFlyouts(Controls.LensPanel);
+    Controls.LensButton:SetSelected(true);
+  elseif (not Controls.LensPanel:IsHidden()) and pControl:IsChecked() then
+    Controls.LensPanel:SetHide(true);
+    Controls.LensButton:SetSelected(false);
   end
-
-  if pCity ~= nil then
-    print_debug("Show citizens for " .. Locale.Lookup(pCity:GetName()))
-    m_tAreaPlotsColored = {}
-
-    local tParameters:table = {};
-    local cityPlotID = Map.GetPlot(pCity:GetX(), pCity:GetY()):GetIndex()
-    tParameters[CityCommandTypes.PARAM_MANAGE_CITIZEN] = UI.GetInterfaceModeParameter(CityCommandTypes.PARAM_MANAGE_CITIZEN);
-
-    local tWorkingPlots:table = {}  -- Plots worked by unlocked citizens
-    local tLockedPlots:table = {}   -- Plots worked by locked citizes
-
-    -- Get city plot and citizens info
-    local tResults:table = CityManager.GetCommandTargets(pCity, CityCommandTypes.MANAGE, tParameters);
-    if tResults == nil then
-      print("ERROR : Could not find plots")
-      return
-    end
-
-    local tPlots:table = tResults[CityCommandResults.PLOTS];
-    local tUnits:table = tResults[CityCommandResults.CITIZENS];
-    local tLockedUnits:table = tResults[CityCommandResults.LOCKED_CITIZENS];
-
-    if tPlots ~= nil then
-      for i, plotID in ipairs(tPlots) do
-        table.insert(m_tAreaPlotsColored, plotID);
-        if (tLockedUnits[i] > 0 or cityPlotID == plotID) then
-          table.insert(tLockedPlots, plotID);
-        elseif (tUnits[i] > 0) then
-          table.insert(tWorkingPlots, plotID);
-        end
-      end
-    end
-
-    local workingColor:number = UI.GetColorValue("COLOR_CITY_PLOT_WORKING");
-    local lockedColor:number = UI.GetColorValue("COLOR_CITY_PLOT_LOCKED");
-
-    if #tWorkingPlots > 0 then
-      UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_GOVERNMENT, localPlayer, tWorkingPlots, workingColor );
-    end
-
-    if #tLockedPlots > 0 then
-      UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_GOVERNMENT, localPlayer, tLockedPlots, lockedColor );
-    end
-
-    m_CitizenManagementOn = true;
-  end
-end
-
-function RefreshCitizenManagementArea(cityID)
-  ClearAreaLens();
-  ShowCitizenManagementArea(cityID);
+  pControl:SetCheck( not pControl:IsChecked() );
 end
 
 -- ===========================================================================
@@ -940,6 +810,11 @@ function OnInputActionTriggered( actionId )
   if (Game.GetLocalPlayer() == -1) then
     return;
   end
+
+  if UI.GetInterfaceMode() == InterfaceModeTypes.DISTRICT_PLACEMENT then
+    return;
+  end
+
   if m_ToggleReligionLensId ~= nil and (actionId == m_ToggleReligionLensId) then
     LensPanelHotkeyControl( Controls.ReligionLensButton );
     ToggleReligionLens();
@@ -971,9 +846,9 @@ function OnInputActionTriggered( actionId )
     UI.PlaySound("Play_UI_Click");
   end
   if m_ToggleTourismLensId ~= nil and (actionId == m_ToggleTourismLensId) then
-        LensPanelHotkeyControl( Controls.TourismLensButton );
-        ToggleTourismLens();
-        UI.PlaySound("Play_UI_Click");
+    LensPanelHotkeyControl( Controls.TourismLensButton );
+    ToggleTourismLens();
+    UI.PlaySound("Play_UI_Click");
   end
   if m_Toggle2DViewId ~= nil and (actionId == m_Toggle2DViewId) then
     UI.PlaySound("Play_UI_Click");
@@ -985,21 +860,6 @@ end
 --  Game Engine Event
 -- ===========================================================================
 function OnInterfaceModeChanged(eOldMode:number, eNewMode:number)
-
-  if SHOW_CITIZEN_MANAGEMENT_INSCREEN then
-    if eOldMode == InterfaceModeTypes.CITY_MANAGEMENT then
-      ClearAreaLens()
-      m_CitizenManagementOn = false
-    end
-
-    if eNewMode == InterfaceModeTypes.CITY_MANAGEMENT then
-      local selectedCity = UI.GetHeadSelectedCity();
-      if (selectedCity ~= nil) then
-        RefreshCitizenManagementArea(selectedCity:GetID())
-      end
-    end
-  end
-
   --and eNewMode ~= InterfaceModeTypes.VIEW_MODAL_LENS
   if eOldMode == InterfaceModeTypes.VIEW_MODAL_LENS then
     if not Controls.LensPanel:IsHidden() then
@@ -1025,7 +885,7 @@ function OnInterfaceModeChanged(eOldMode:number, eNewMode:number)
         i = i + 1
         lensButtonInstance = m_LensButtonIM:GetAllocatedInstance(i)
       end
-      
+
       -- If any modded lens is active clear it
       if m_CurrentModdedLensOn ~= "NONE" then
         if UILens.IsLayerOn( LensLayers.HEX_COLORING_APPEAL_LEVEL ) then
@@ -1033,39 +893,9 @@ function OnInterfaceModeChanged(eOldMode:number, eNewMode:number)
         end
         SetActiveModdedLens("NONE")
       end
-      
+
       LuaEvents.ML_CloseLensPanels()
     end
-  end
-end
-
-function OnCitySelectionChanged(owner, ID, i, j, k, bSelected, bEditable)
-  if owner ~= Game.GetLocalPlayer() then
-    return
-  end
-
-  if SHOW_CITIZEN_MANAGEMENT_INSCREEN then
-    if bSelected and m_CurrentAreaLensOn == AREA_LENS_ID.CITIZEN_MANAGEMENT then
-      RefreshCitizenManagementArea(ID)
-    end
-  end
-end
-
-function OnCityWorkerChanged(ownerPlayerID:number, cityID:number)
-  if SHOW_CITIZEN_MANAGEMENT_INSCREEN and ownerPlayerID == Game.GetLocalPlayer() and
-      m_CurrentAreaLensOn == AREA_LENS_ID.CITIZEN_MANAGEMENT then
-    RefreshCitizenManagementArea(cityID)
-  end
-end
-
-function OnCityMadePurchase(owner:number, cityID:number, plotX:number, plotY:number, purchaseType, objectType)
-  if SHOW_CITIZEN_MANAGEMENT_INSCREEN and owner == Game.GetLocalPlayer() and
-      m_CurrentAreaLensOn == AREA_LENS_ID.CITIZEN_MANAGEMENT and
-      purchaseType == EventSubTypes.PLOT then
-
-    -- Add plot so that the plot is properly cleared
-    table.insert(m_tAreaPlotsColored, Map.GetPlotIndex(plotX, plotY))
-    RefreshCitizenManagementArea(cityID)
   end
 end
 
@@ -1119,7 +949,7 @@ function OnInputHandler( pInputStruct:table )
   -- Skip all handling when dragging is disabled or the minimap is collapsed
   if m_isMouseDragEnabled and not m_isCollapsed then
     local msg = pInputStruct:GetMessageType( );
-    
+
     -- Enable drag on LMB down
     if msg == MouseEvents.LButtonDown then
       local minix, miniy = GetMinimapMouseCoords( pInputStruct:GetX(), pInputStruct:GetY() );
@@ -1157,6 +987,7 @@ function OnInputHandler( pInputStruct:table )
       end
       m_wasMouseInMinimap = isMouseInMinimap
       return isMouseInMinimap; -- Only consume event if it's inside the minimap.
+
     end
 
     -- TODO the letterbox background should block mouse input
@@ -1188,7 +1019,7 @@ end
 -- ===========================================================================
 function SetModLens()
   if m_CurrentModdedLensOn ~= nil and m_CurrentModdedLensOn ~= "NONE" and
-  g_ModLenses[m_CurrentModdedLensOn] ~= nil then
+      g_ModLenses[m_CurrentModdedLensOn] ~= nil then
     print("Highlighting " .. m_CurrentModdedLensOn .. " hexes")
     local getPlotColorFn = g_ModLenses[m_CurrentModdedLensOn].GetColorPlotTable
     if getPlotColorFn ~= nil then
@@ -1233,13 +1064,13 @@ end
 function ToggleModLens(buttonControl:table, lensName:string)
   if buttonControl:IsChecked() then
     SetActiveModdedLens(lensName);
-    
+
     -- Check if the appeal lens is already active. Needed to clear any modded lens
     if UILens.IsLayerOn(LensLayers.HEX_COLORING_APPEAL_LEVEL) then
       -- Unapply the appeal lens, so it can be cleared from the screen
       UILens.SetActive("Default");
     end
-    
+
     LuaEvents.ML_CloseLensPanels()
     if g_ModLenses[lensName].OnToggle ~= nil then
       -- print("Toggling....")
@@ -1262,7 +1093,7 @@ function InitLens(lensName, modLens)
   if modLens.Initialize ~= nil then
     modLens.Initialize()
   end
-  
+
   -- Add this lens to button stack
   local modLensToggle = m_LensButtonIM:GetInstance();
   local pLensButton = modLensToggle.LensButton:GetTextButton()
@@ -1270,62 +1101,62 @@ function InitLens(lensName, modLens)
   pLensButton:LocalizeAndSetText(modLens.LensButtonText)
   modLensToggle.LensButton:SetToolTipString(pToolTip)
   modLensToggle.LensButton:RegisterCallback(Mouse.eLClick,
-  function()
-    ToggleModLens(modLensToggle.LensButton, lensName);
-  end
-)
+    function()
+      ToggleModLens(modLensToggle.LensButton, lensName);
+    end
+  )
 end
 
 function AddLensEntry(lensKey:string, lensEntry:table)
-g_ModLenses[lensKey] = lensEntry
-InitLens(lensKey, lensEntry)
+  g_ModLenses[lensKey] = lensEntry
+  InitLens(lensKey, lensEntry)
 end
 
 function InitializeModLens()
-print("Initializing " .. table.count(g_ModLenses) .. " lenses")
-for lensName, modLens in pairs(g_ModLenses) do
-  InitLens(lensName, modLens)
-end
+  print("Initializing " .. table.count(g_ModLenses) .. " lenses")
+  for lensName, modLens in pairs(g_ModLenses) do
+    InitLens(lensName, modLens)
+  end
 end
 
 function HandleMouseForModdedLens( mousex:number, mousey:number )
--- Don't do anything if mouse is dragging
+  -- Don't do anything if mouse is dragging
   if not m_isMouseDragging then
     -- Get plot under cursor
     local plotId = UI.GetCursorPlotID();
     if (not Map.IsPlot(plotId)) then
       return;
     end
-    
+
     -- If the cursor plot has not changed don't refresh
     if (m_CurrentCursorPlotID == plotId) then
       return
     end
-    
+
     m_CurrentCursorPlotID = plotId
-    
+
     local pPlot = Map.GetPlotByIndex(m_CurrentCursorPlotID)
     local selectedCity = UI.GetHeadSelectedCity()
     local selectedUnit = UI.GetHeadSelectedUnit()
-    
+
     -- Handler for alternate settler lens
     local ctrlDown = m_CtrlDown
     if m_SetterLensAlternateInverse then
       ctrlDown = not ctrlDown
     end
-    
+
     if ctrlDown then
       if selectedUnit ~= nil then
         local unitType = GetUnitType(selectedUnit:GetOwner(), selectedUnit:GetID());
         if unitType == "UNIT_SETTLER" then
           RefreshSettlerLens();
         -- else
-          --     print(unitType)
+        --     print(unitType)
         end
-        
-        -- Clear Settler lens, if not in modal screen
+
+      -- Clear Settler lens, if not in modal screen
       elseif UI.GetInterfaceMode() ~= InterfaceModeTypes.VIEW_MODAL_LENS then
-        
+
         ClearSettlerLens();
       end
     end
@@ -1340,8 +1171,8 @@ function Initialize()
   m_MiniMap_xmloffsety = Controls.MiniMap:GetOffsetY();
   m_ContinentsCache = Map.GetContinentsInUse();
 
-  UI.SetMinimapImageControl(Controls.MinimapImage);
-  Controls.LensChooserList:CalculateSize();
+  Controls.MinimapImage:RegisterSizeChanged( OnMinimapImageSizeChanged );
+  UI.SetMinimapImageControl( Controls.MinimapImage );
 
   ContextPtr:SetInputHandler( OnInputHandler, true );
   ContextPtr:SetShutdown( OnShutdown );
@@ -1404,9 +1235,6 @@ function Initialize()
   LuaEvents.MinimapPanel_ToggleGrid.Add( ToggleGrid );
   LuaEvents.MinimapPanel_RefreshMinimapOptions.Add( RefreshMinimapOptions );
 
-  -- For modded lenses
-  Events.CitySelectionChanged.Add( OnCitySelectionChanged );
-
   -- CQUI Handlers
   LuaEvents.CQUI_Option_ToggleBindings.Add( CQUI_OnToggleBindings );
   LuaEvents.CQUI_Option_ToggleYields.Add( ToggleYieldIcons );
@@ -1415,15 +1243,6 @@ function Initialize()
   LuaEvents.CQUI_SettingsInitialized.Add( CQUI_ToggleYieldIcons );
   Events.LoadScreenClose.Add( CQUI_OnSettingsUpdate ); -- Astog: Update settings when load screen close
   -- CQUI_OnSettingsUpdate()
-
-  -- For Area Lens
-  Events.CityWorkerChanged.Add( OnCityWorkerChanged );
-  Events.CityMadePurchase.Add( OnCityMadePurchase );
-
-  -- External Lens Controls
-  LuaEvents.Area_ShowCitizenManagement.Add( ShowCitizenManagementArea );
-  LuaEvents.Area_RefreshCitizenManagement.Add( RefreshCitizenManagementArea );
-  LuaEvents.Area_ClearCitizenManagement.Add( ClearAreaLens );
 
   -- Mod Lens Support
   LuaEvents.MinimapPanel_SetActiveModLens.Add( SetActiveModdedLens );

--- a/Integrations/ML/UI/minimappanel.lua
+++ b/Integrations/ML/UI/minimappanel.lua
@@ -64,12 +64,6 @@ local m_isMouseDragging         :boolean = false; -- Was LMB clicked inside the 
 local m_hasMouseDragged         :boolean = false; -- Has there been any movements since m_isMouseDragging became true?
 local m_wasMouseInMinimap       :boolean = false; -- Was the mouse over the minimap the last time we checked?
 
-local CQUI_MapSize = 512;
-local CQUI_MapImageScaler = 0.5;
-
-local CQUI_MapBackingXSizeDiff = 27;
-local CQUI_MapBackingYSizeDiff = 54;
-
 -- ===========================================================================
 --  FUNCTIONS
 -- ===========================================================================
@@ -86,46 +80,6 @@ function CQUI_OnToggleBindings(mode: number)
   elseif(mode == 2) then
   Controls.CQUI_ToggleBindings2:SetCheck(true);
   end
-end
-
-function CQUI_UpdateMinimapSize()
-  -- AZURENCY : TODO remove this resize totally since its in base game now
-  local size = GameConfiguration.GetValue("CQUI_MinimapSize");
-  if size ~= nil then
-    CQUI_MapSize = size
-  else
-    print_debug("Using previous minimap size")
-  end
-
-  -- AZURENCY : Quick fix to avoid visual glitch when CQUI_MapSize is too big (with old saves before the setting change)
-  if CQUI_MapSize > 100 then
-    CQUI_MapSize = 100
-  end
-
-  Options.SetGraphicsOption("General", "MinimapSize", CQUI_MapSize/100);
-  UI.SetMinimapSize(CQUI_MapSize/100);
-
-  --Cycles the minimap after resizing
-  -- local xSize = CQUI_MapSize
-  -- local ySize = CQUI_MapSize * CQUI_MapImageScaler
-  -- Controls.MinimapContainer:SetSizeVal(xSize, ySize);
-  -- Controls.MinimapImage:SetSizeVal(xSize, ySize);
-  -- Controls.MinimapBacking:SetSizeVal(xSize + CQUI_MapBackingXSizeDiff, ySize + CQUI_MapBackingYSizeDiff);
-  -- Controls.CollapseAnim:SetEndVal(0, Controls.MinimapImage:GetOffsetY() + Controls.MinimapImage:GetSizeY());
-
-  --Squeezes the map buttons if extra space is needed
-  if(CQUI_MapSize < 15) then
-    Controls.OptionsStack:SetPadding(-7);
-  else
-    Controls.OptionsStack:SetPadding(-3);
-  end
-end
-
-function CQUI_OnSettingsUpdate()
-  SHOW_CITIZEN_MANAGEMENT_INSCREEN = GameConfiguration.GetValue("CQUI_ShowCityMangeAreaInScreen");
-
-  --Cycles the minimap after resizing
-  CQUI_UpdateMinimapSize();
 end
 
 function CQUI_ToggleYieldIcons()
@@ -1238,11 +1192,7 @@ function Initialize()
   -- CQUI Handlers
   LuaEvents.CQUI_Option_ToggleBindings.Add( CQUI_OnToggleBindings );
   LuaEvents.CQUI_Option_ToggleYields.Add( ToggleYieldIcons );
-  LuaEvents.CQUI_SettingsUpdate.Add( CQUI_OnSettingsUpdate );
-  LuaEvents.CQUI_SettingsInitialized.Add( CQUI_UpdateMinimapSize );
   LuaEvents.CQUI_SettingsInitialized.Add( CQUI_ToggleYieldIcons );
-  Events.LoadScreenClose.Add( CQUI_OnSettingsUpdate ); -- Astog: Update settings when load screen close
-  -- CQUI_OnSettingsUpdate()
 
   -- Mod Lens Support
   LuaEvents.MinimapPanel_SetActiveModLens.Add( SetActiveModdedLens );

--- a/Integrations/ML/UI/minimappanel.lua
+++ b/Integrations/ML/UI/minimappanel.lua
@@ -2,6 +2,7 @@
 --  MINIMAP PANEL
 -- ===========================================================================
 include( "InstanceManager" );
+include( "Civ6Common" );
 
 -- ===========================================================================
 --  MODDED LENS
@@ -977,15 +978,15 @@ end
 function SetModLens()
   if m_CurrentModdedLensOn ~= nil and m_CurrentModdedLensOn ~= "NONE" and
       g_ModLenses[m_CurrentModdedLensOn] ~= nil then
-    print("Highlighting " .. m_CurrentModdedLensOn .. " hexes")
+    print_debug("Highlighting " .. m_CurrentModdedLensOn .. " hexes")
     local getPlotColorFn = g_ModLenses[m_CurrentModdedLensOn].GetColorPlotTable
     if getPlotColorFn ~= nil then
       SetModLensHexes(getPlotColorFn())
     else
-      print("ERROR: No Plot Color Function")
+      print_debug("ERROR: No Plot Color Function")
     end
   else
-    print("ERROR: Given lens has no entry")
+    print_debug("ERROR: Given lens has no entry")
   end
 end
 
@@ -994,7 +995,7 @@ function SetModLensHexes(colorPlot:table)
   local localPlayer = Game.GetLocalPlayer()
   for color, plots in pairs(colorPlot) do
     if table.count(plots) > 0 then
-      -- print("Showing " .. table.count(plots) .. " plots with color " .. color)
+      print_debug("Showing " .. table.count(plots) .. " plots with color " .. color)
       UILens.SetLayerHexesColoredArea( LensLayers.HEX_COLORING_APPEAL_LEVEL, localPlayer, plots, color);
     end
   end
@@ -1007,11 +1008,13 @@ function OnApplyCustomLens(colorPlot:table)
     SetActiveModdedLens("ML_CUSTOM")
     UILens.ToggleLayerOn(LensLayers.HEX_COLORING_APPEAL_LEVEL)
   end
+  -- print("Toggling on")
   SetModLensHexes(colorPlot)
 end
 
 function OnClearCustomLens()
   if UILens.IsLayerOn(LensLayers.HEX_COLORING_APPEAL_LEVEL) then
+    -- print("Toggling off")
     UILens.ToggleLayerOff(LensLayers.HEX_COLORING_APPEAL_LEVEL)
   end
   SetActiveModdedLens("NONE")

--- a/Integrations/ML/morelenses_colors.sql
+++ b/Integrations/ML/morelenses_colors.sql
@@ -78,11 +78,11 @@ VALUES                  (   'COLOR_FIXABLE_NATURALIST_LENS',    '0.56',     '0.0
 
 -- City Manager Colors
 INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
-VALUES                  (   'COLOR_CITY_PLOT_WORKING',          '1',        '0.5',      '0',        '0.2');
+VALUES                  (   'COLOR_CITY_PLOT_WORKING',          '0.9',      '0.0',      '0.05',     '0.5');
 INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
 VALUES                  (   'COLOR_CITY_PLOT_LOCKED',           '0',        '1',        '0',        '0.2');
 INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)
-VALUES                  (   'COLOR_AREA_LENS_NEUTRAL',          '0',        '0',        '0',        '0.0');
+VALUES                  (   'COLOR_CITY_PLOT_CULTURE',          '0.56',     '0.0',      '0.98',     '0.5');
 
 -- Alternate Settler Colors
 INSERT INTO Colors      (   Type,                               Red,        Green,      Blue,       Alpha)


### PR DESCRIPTION
- Fixes issue with some lenses not being imported
- Removed CQUI minimap size setting
- Readded Citizen management area lens on hover and in screen. Uses appeal lens as base rather than government. Note: The final implementation is still hacky because Firaxis made it that appeal lens is blocked during citizen management mode. So to force it there is refresh of lenses that causes a flicker of yields. This only occurs when in city screen, not during hover. It can still be disabled from CQUI settings panel. But I want to find a better solution to this in future. Maybe @Azurency or other CQUI devs could find it.
- Removed some deprecated LuaEvents calls.
- Moved most print statements to CQUI `debug_print`