### PR TITLE
Real housing - some fixes when a tech that adds housing is boosted

### DIFF
--- a/Assets/UI/Panels/citypanel.lua
+++ b/Assets/UI/Panels/citypanel.lua
@@ -1536,7 +1536,6 @@ function Initialize()
   LuaEvents.CQUI_SettingsUpdate.Add( CQUI_SettingsUpdate );
   LuaEvents.RefreshCityPanel.Add(Refresh);
   LuaEvents.CQUI_RealHousingFromImprovementsCalculated.Add(CQUI_HousingFromImprovementsTableInsert);    -- CQUI get real housing from improvements values
-  LuaEvents.CQUI_AllCitiesInfoUpdated.Add( Refresh );    -- CQUI update real housing from improvements for a selected city when all cities are updated
   LuaEvents.CQUI_AllCitiesInfoUpdatedOnTechCivicBoost.Add( CQUI_UpdateAllCitiesData );    -- CQUI update all cities data including real housing when tech/civic that adds housing is boosted and research is completed
   Events.ImprovementRemovedFromMap.Add( CQUI_OnImprovementRemoved );    -- CQUI add plot ID to a table when improvement removed. We use it to update real housing
 

--- a/Assets/UI/Panels/citypanel.lua
+++ b/Assets/UI/Panels/citypanel.lua
@@ -1403,6 +1403,17 @@ function OnTutorial_ContextDisableItems( contextName:string, kIdsToDisable:table
 end
 
 -- ===========================================================================
+-- CQUI update all cities data including real housing when tech/civic that adds housing is boosted and research is completed
+function CQUI_UpdateAllCitiesData()
+
+  local PlayerID = Game.GetLocalPlayer();
+  local m_kCity:table = Players[PlayerID]:GetCities();
+  for i, kCity in m_kCity:Members() do
+    CityManager.RequestCommand(kCity, CityCommandTypes.SET_FOCUS, nil);
+  end
+end
+
+-- ===========================================================================
 -- CQUI get real housing from improvements
 function CQUI_HousingFromImprovementsTableInsert (pCityID, CQUI_HousingFromImprovements)
   CQUI_HousingFromImprovementsTable[pCityID] = CQUI_HousingFromImprovements;
@@ -1503,9 +1514,8 @@ function Initialize()
   LuaEvents.CQUI_SettingsUpdate.Add( CQUI_SettingsUpdate );
   LuaEvents.RefreshCityPanel.Add(Refresh);
   LuaEvents.CQUI_RealHousingFromImprovementsCalculated.Add(CQUI_HousingFromImprovementsTableInsert);    -- CQUI get real housing from improvements values
-  LuaEvents.CQUI_CityLostTileToCultureBomb.Add( Refresh );    -- CQUI update real housing from improvements when a city lost tile to a Culture Bomb
-  LuaEvents.CQUI_IndiaPlayerResearchedSanitation.Add( Refresh );    -- CQUI update real housing from improvements when play as India and researched Sanitation
-  LuaEvents.CQUI_IndonesiaPlayerResearchedMassProduction.Add( Refresh );    -- CQUI update real housing from improvements when play as Indonesia and researched Mass Production
+  LuaEvents.CQUI_AllCitiesInfoUpdated.Add( Refresh );    -- CQUI update real housing from improvements for a selected city when all cities are updated
+  LuaEvents.CQUI_AllCitiesInfoUpdatedOnTechCivicBoost.Add( CQUI_UpdateAllCitiesData );    -- CQUI update all cities data when tech/civic that adds housing is boosted and research is completed
 
   -- Truncate possible static text overflows
   TruncateStringWithTooltip(Controls.BreakdownLabel,  MAX_BEFORE_TRUNC_STATIC_LABELS, Controls.BreakdownLabel:GetText());

--- a/Assets/UI/Panels/citypanel.lua
+++ b/Assets/UI/Panels/citypanel.lua
@@ -63,6 +63,7 @@ local m_kTutorialDisabledControls :table  = nil;
 local m_GrowthPlot          :number = -1;
 
 local CQUI_HousingFromImprovementsTable :table = {};    -- CQUI real housing from improvements table
+local CQUI_ImprovementRemoved :table = {};    -- CQUI: a table we use to update real housing when improvement removed
 
 -- ====================CQUI Cityview==========================================
 
@@ -950,9 +951,18 @@ function OnTileImproved(x, y)
       LuaEvents.CityPanel_LiveCityDataChanged( m_kData, true );
       --LuaEvents.UpdateBanner(Game.GetLocalPlayer(), m_pCity:GetID());
 
-      -- CQUI update city's real housing
-      local pCityID = m_pCity:GetID();
-      LuaEvents.CQUI_CityInfoUpdated(pCityID);
+      -- CQUI update city's real housing only if improvement adds housing or if it's removed
+      local plotID = plot:GetIndex();
+      if Map.GetPlotDistance(m_pCity:GetX(), m_pCity:GetY(), x, y) <= 3 then
+        local eImprovementType :number = plot:GetImprovementType();
+        if ( eImprovementType ~= -1 and GameInfo.Improvements[eImprovementType].Housing > 0 ) or CQUI_ImprovementRemoved[plotID] == true then
+          local pCityID = m_pCity:GetID();
+          LuaEvents.CQUI_CityInfoUpdated(PlayerID, pCityID);
+        end
+      end
+      if CQUI_ImprovementRemoved[plotID] == true then
+        CQUI_ImprovementRemoved[plotID] = nil;
+      end
     end
   end
 end
@@ -1404,12 +1414,24 @@ end
 
 -- ===========================================================================
 -- CQUI update all cities data including real housing when tech/civic that adds housing is boosted and research is completed
-function CQUI_UpdateAllCitiesData()
-
-  local PlayerID = Game.GetLocalPlayer();
-  local m_kCity:table = Players[PlayerID]:GetCities();
+function CQUI_UpdateAllCitiesData(PlayerID)
+  local m_kCity :table = Players[PlayerID]:GetCities();
   for i, kCity in m_kCity:Members() do
     CityManager.RequestCommand(kCity, CityCommandTypes.SET_FOCUS, nil);
+  end
+end
+
+-- ===========================================================================
+-- CQUI add plot ID to a table when improvement removed. We use it to update real housing
+function CQUI_OnImprovementRemoved(x, y)
+  local plot :table = Map.GetPlot(x, y);
+  local PlayerID = Game.GetLocalPlayer();
+  m_pCity = Cities.GetPlotPurchaseCity(plot);
+  if m_pCity ~= nil then
+    if PlayerID == m_pCity:GetOwner() then
+      local plotID = plot:GetIndex();
+      CQUI_ImprovementRemoved[plotID] = true;
+    end
   end
 end
 
@@ -1515,7 +1537,8 @@ function Initialize()
   LuaEvents.RefreshCityPanel.Add(Refresh);
   LuaEvents.CQUI_RealHousingFromImprovementsCalculated.Add(CQUI_HousingFromImprovementsTableInsert);    -- CQUI get real housing from improvements values
   LuaEvents.CQUI_AllCitiesInfoUpdated.Add( Refresh );    -- CQUI update real housing from improvements for a selected city when all cities are updated
-  LuaEvents.CQUI_AllCitiesInfoUpdatedOnTechCivicBoost.Add( CQUI_UpdateAllCitiesData );    -- CQUI update all cities data when tech/civic that adds housing is boosted and research is completed
+  LuaEvents.CQUI_AllCitiesInfoUpdatedOnTechCivicBoost.Add( CQUI_UpdateAllCitiesData );    -- CQUI update all cities data including real housing when tech/civic that adds housing is boosted and research is completed
+  Events.ImprovementRemovedFromMap.Add( CQUI_OnImprovementRemoved );    -- CQUI add plot ID to a table when improvement removed. We use it to update real housing
 
   -- Truncate possible static text overflows
   TruncateStringWithTooltip(Controls.BreakdownLabel,  MAX_BEFORE_TRUNC_STATIC_LABELS, Controls.BreakdownLabel:GetText());

--- a/Assets/UI/Panels/citypaneloverview.lua
+++ b/Assets/UI/Panels/citypaneloverview.lua
@@ -982,7 +982,7 @@ function OnHide()
 end
 
 -- ===========================================================================
---CQUI get real housing from improvements
+-- CQUI get real housing from improvements
 function CQUI_HousingFromImprovementsTableInsert (pCityID, CQUI_HousingFromImprovements)
   CQUI_HousingFromImprovementsTable[pCityID] = CQUI_HousingFromImprovements;
 end
@@ -1008,7 +1008,7 @@ function Initialize()
   LuaEvents.CityPanel_ToggleOverviewBuildings.Add( OnToggleBuildingsTab );
   LuaEvents.CityPanel_ToggleOverviewReligion.Add( OnToggleReligionTab );
   LuaEvents.CityPanel_LiveCityDataChanged.Add( OnLiveCityDataChanged )
-  LuaEvents.CQUI_RealHousingFromImprovementsCalculated.Add(CQUI_HousingFromImprovementsTableInsert);    --CQUI get real housing from improvements values
+  LuaEvents.CQUI_RealHousingFromImprovementsCalculated.Add(CQUI_HousingFromImprovementsTableInsert);    -- CQUI get real housing from improvements values
 
   Events.SystemUpdateUI.Add( OnUpdateUI );
   Events.CityNameChanged.Add(OnCityNameChanged);

--- a/Assets/UI/Panels/citypaneloverview.lua
+++ b/Assets/UI/Panels/citypaneloverview.lua
@@ -81,7 +81,7 @@ m_tabs = nil;
 
 
 --CQUI Members
-local CQUI_HousingFromImprovementsTable = {};
+local CQUI_HousingFromImprovementsTable :table = {};    -- CQUI real housing from improvements table
 local CQUI_ShowCityDetailAdvisor :boolean = false;
 
 function CQUI_OnSettingsUpdate()

--- a/Assets/UI/Panels/notificationpanel.lua
+++ b/Assets/UI/Panels/notificationpanel.lua
@@ -1324,14 +1324,14 @@ function OnTechBoostActivateNotification( notificationEntry : NotificationType, 
 				if techIndex == GameInfo.Technologies["TECH_SANITATION"].Index then    -- Sanitation
 				  if PlayerConfigurations[notificationEntry.m_PlayerID]:GetCivilizationTypeName() == "CIVILIZATION_INDIA" then
 				    if Players[notificationEntry.m_PlayerID]:GetTechs():HasTech(techIndex) then
-				      LuaEvents.CQUI_AllCitiesInfoUpdatedOnTechCivicBoost();
+				      LuaEvents.CQUI_AllCitiesInfoUpdatedOnTechCivicBoost(notificationEntry.m_PlayerID);
 				    end
 				  end
 				-- CQUI update all cities real housing when play as Indonesia and boosted and researched Mass Production
 				elseif techIndex == GameInfo.Technologies["TECH_MASS_PRODUCTION"].Index then    -- Mass Production
 				  if PlayerConfigurations[notificationEntry.m_PlayerID]:GetCivilizationTypeName() == "CIVILIZATION_INDONESIA" then
 				    if Players[notificationEntry.m_PlayerID]:GetTechs():HasTech(techIndex) then
-				      LuaEvents.CQUI_AllCitiesInfoUpdatedOnTechCivicBoost();
+				      LuaEvents.CQUI_AllCitiesInfoUpdatedOnTechCivicBoost(notificationEntry.m_PlayerID);
 				    end
 				  end
 				end
@@ -1459,7 +1459,7 @@ function OnNotificationAdded( playerID:number, notificationID:number )
 
     -- CQUI: Notification when a City lost tile to a Culture Bomb. We use it to update real housing.
     if pNotification:GetType() == GameInfo.Notifications["NOTIFICATION_TILE_LOST_CULTURE_BOMB"].Hash then
-      LuaEvents.CQUI_AllCitiesInfoUpdated();
+      LuaEvents.CQUI_AllCitiesInfoUpdated(playerID);
     end
   end
 end

--- a/Assets/UI/Panels/notificationpanel.lua
+++ b/Assets/UI/Panels/notificationpanel.lua
@@ -1457,7 +1457,8 @@ function OnNotificationAdded( playerID:number, notificationID:number )
       UI.DataError("Notification added Event but not found in manager. PlayerID - " .. tostring(playerID) .. " Notification ID - " .. tostring(notificationID));
     end
 
-    if pNotification:GetType() == GameInfo.Notifications["NOTIFICATION_TILE_LOST_CULTURE_BOMB"].Hash then    -- CQUI: Notification when a City lost tile to a Culture Bomb. We use it to update real housing.
+    -- CQUI: Notification when a City lost tile to a Culture Bomb. We use it to update real housing.
+    if pNotification:GetType() == GameInfo.Notifications["NOTIFICATION_TILE_LOST_CULTURE_BOMB"].Hash then
       LuaEvents.CQUI_AllCitiesInfoUpdated();
     end
   end

--- a/Assets/UI/Panels/notificationpanel.lua
+++ b/Assets/UI/Panels/notificationpanel.lua
@@ -1459,7 +1459,8 @@ function OnNotificationAdded( playerID:number, notificationID:number )
 
     -- CQUI: Notification when a City lost tile to a Culture Bomb. We use it to update real housing.
     if pNotification:GetType() == GameInfo.Notifications["NOTIFICATION_TILE_LOST_CULTURE_BOMB"].Hash then
-      LuaEvents.CQUI_AllCitiesInfoUpdated(playerID);
+      local x, y = pNotification:GetLocation();
+      LuaEvents.CQUI_CityLostTileToCultureBomb(playerID, x, y);
     end
   end
 end

--- a/Assets/UI/Panels/notificationpanel.lua
+++ b/Assets/UI/Panels/notificationpanel.lua
@@ -1319,6 +1319,22 @@ function OnTechBoostActivateNotification( notificationEntry : NotificationType, 
 			local techSource = pNotification:GetValue("TechSource"); 
 			if(techIndex ~= nil and techProgress ~= nil and techSource ~= nil) then
 				LuaEvents.NotificationPanel_ShowTechBoost(notificationEntry.m_PlayerID, techIndex, techProgress, techSource);
+
+				-- CQUI update all cities real housing when play as India and boosted and researched Sanitation
+				if techIndex == GameInfo.Technologies["TECH_SANITATION"].Index then    -- Sanitation
+				  if PlayerConfigurations[notificationEntry.m_PlayerID]:GetCivilizationTypeName() == "CIVILIZATION_INDIA" then
+				    if Players[notificationEntry.m_PlayerID]:GetTechs():HasTech(techIndex) then
+				      LuaEvents.CQUI_AllCitiesInfoUpdatedOnTechCivicBoost();
+				    end
+				  end
+				-- CQUI update all cities real housing when play as Indonesia and boosted and researched Mass Production
+				elseif techIndex == GameInfo.Technologies["TECH_MASS_PRODUCTION"].Index then    -- Mass Production
+				  if PlayerConfigurations[notificationEntry.m_PlayerID]:GetCivilizationTypeName() == "CIVILIZATION_INDONESIA" then
+				    if Players[notificationEntry.m_PlayerID]:GetTechs():HasTech(techIndex) then
+				      LuaEvents.CQUI_AllCitiesInfoUpdatedOnTechCivicBoost();
+				    end
+				  end
+				end
 			end
     end
   end
@@ -1441,8 +1457,8 @@ function OnNotificationAdded( playerID:number, notificationID:number )
       UI.DataError("Notification added Event but not found in manager. PlayerID - " .. tostring(playerID) .. " Notification ID - " .. tostring(notificationID));
     end
 
-    if notificationID	== 577 then                   -- CQUI: Notification when a City lost tile to a Culture Bomb (Index == 577)
-      LuaEvents.CQUI_CityLostTileToCultureBomb();
+    if pNotification:GetType() == GameInfo.Notifications["NOTIFICATION_TILE_LOST_CULTURE_BOMB"].Hash then    -- CQUI: Notification when a City lost tile to a Culture Bomb. We use it to update real housing.
+      LuaEvents.CQUI_AllCitiesInfoUpdated();
     end
   end
 end

--- a/Assets/UI/Screens/techtree.lua
+++ b/Assets/UI/Screens/techtree.lua
@@ -1203,12 +1203,12 @@ function OnResearchComplete( ePlayer:number, eTech:number)
     -- CQUI update all cities real housing when play as India and researched Sanitation
     if eTech == GameInfo.Technologies["TECH_SANITATION"].Index then    -- Sanitation
       if (PlayerConfigurations[ePlayer]:GetCivilizationTypeName() == "CIVILIZATION_INDIA") then
-        LuaEvents.CQUI_AllCitiesInfoUpdated();
+        LuaEvents.CQUI_AllCitiesInfoUpdated(ePlayer);
       end
     -- CQUI update all cities real housing when play as Indonesia and researched Mass Production
     elseif eTech == GameInfo.Technologies["TECH_MASS_PRODUCTION"].Index then    -- Mass Production
       if (PlayerConfigurations[ePlayer]:GetCivilizationTypeName() == "CIVILIZATION_INDONESIA") then
-        LuaEvents.CQUI_AllCitiesInfoUpdated();
+        LuaEvents.CQUI_AllCitiesInfoUpdated(ePlayer);
       end
     end
   end

--- a/Assets/UI/Screens/techtree.lua
+++ b/Assets/UI/Screens/techtree.lua
@@ -1211,7 +1211,6 @@ function OnResearchComplete( ePlayer:number, eTech:number)
         LuaEvents.CQUI_AllCitiesInfoUpdated();
       end
     end
-
   end
 end
 

--- a/Assets/UI/Screens/techtree.lua
+++ b/Assets/UI/Screens/techtree.lua
@@ -1201,14 +1201,14 @@ function OnResearchComplete( ePlayer:number, eTech:number)
         --------------------------------------------------------------------------
 
     -- CQUI update all cities real housing when play as India and researched Sanitation
-    if eTech == 40 then    -- Sanitation (Index == 40)
+    if eTech == GameInfo.Technologies["TECH_SANITATION"].Index then    -- Sanitation
       if (PlayerConfigurations[ePlayer]:GetCivilizationTypeName() == "CIVILIZATION_INDIA") then
-        LuaEvents.CQUI_IndiaPlayerResearchedSanitation();
+        LuaEvents.CQUI_AllCitiesInfoUpdated();
       end
     -- CQUI update all cities real housing when play as Indonesia and researched Mass Production
-    elseif eTech == 27 then    -- Mass Production (Index == 27)
+    elseif eTech == GameInfo.Technologies["TECH_MASS_PRODUCTION"].Index then    -- Mass Production
       if (PlayerConfigurations[ePlayer]:GetCivilizationTypeName() == "CIVILIZATION_INDONESIA") then
-        LuaEvents.CQUI_IndonesiaPlayerResearchedMassProduction();
+        LuaEvents.CQUI_AllCitiesInfoUpdated();
       end
     end
 

--- a/Assets/UI/WorldView/citybannermanager.lua
+++ b/Assets/UI/WorldView/citybannermanager.lua
@@ -1131,7 +1131,7 @@ function CityBanner.UpdateStats( self : CityBanner)
         -- CQUI get real housing from improvements value
         local pCityID = pCity:GetID();
         if CQUI_HousingUpdated[localPlayerID] == nil or CQUI_HousingUpdated[localPlayerID][pCityID] ~= true then
-          CQUI_RealHousingFromImprovements(localPlayerID, pCityID);
+          CQUI_RealHousingFromImprovements(pCity, localPlayerID, pCityID);
         end
 
         if g_smartbanner and g_smartbanner_population then
@@ -3401,9 +3401,8 @@ end
 
 -- ===========================================================================
 -- CQUI calculate real housing from improvements
-function CQUI_RealHousingFromImprovements(PlayerID, pCityID)
+function CQUI_RealHousingFromImprovements(pCity, PlayerID, pCityID)
   local CQUI_HousingFromImprovements = 0;
-  local pCity = CityManager.GetCity(PlayerID, pCityID);
   local kCityPlots :table = Map.GetCityPlots():GetPurchasedPlots(pCity);
   if kCityPlots ~= nil then
     for _, plotID in pairs(kCityPlots) do
@@ -3453,7 +3452,6 @@ end
 -- CQUI update city's real housing from improvements
 function CQUI_OnCityInfoUpdated(PlayerID, pCityID)
   CQUI_HousingUpdated[PlayerID][pCityID] = nil;
-  CQUI_RealHousingFromImprovements(PlayerID, pCityID)
 end
 
 -- ===========================================================================

--- a/Assets/UI/WorldView/citybannermanager.lua
+++ b/Assets/UI/WorldView/citybannermanager.lua
@@ -3364,25 +3364,27 @@ function CQUI_RealHousingFromImprovements(pCity)
   if tPlots ~= nil and (table.count(tPlots) > 0) then
     for i, plotId in pairs(tPlots) do
       local kPlot	:table = Map.GetPlotByIndex(plotId);
-      local eImprovementType :number = kPlot:GetImprovementType();
-      if( eImprovementType ~= -1 ) then
-        local kImprovementData = GameInfo.Improvements[eImprovementType].Housing;
-        if kImprovementData == 1 then    -- farms, pastures etc.
-          CQUI_HousingFromImprovements = CQUI_HousingFromImprovements + 1;
-        elseif kImprovementData == 2 then    -- stepwells and kampungs
-          if GameInfo.Improvements[eImprovementType].ImprovementType == "IMPROVEMENT_STEPWELL" then    -- stepwells
-            local CQUI_PlayerResearchedSanitation :boolean = Players[Game.GetLocalPlayer()]:GetTechs():HasTech(GameInfo.Technologies["TECH_SANITATION"].Index);    -- check if a player researched Sanitation
-            if not CQUI_PlayerResearchedSanitation then
-              CQUI_HousingFromImprovements = CQUI_HousingFromImprovements + 2;
-            else
-              CQUI_HousingFromImprovements = CQUI_HousingFromImprovements + 4;
-            end
-          else    -- kampungs
-            local CQUI_PlayerResearchedMassProduction :boolean = Players[Game.GetLocalPlayer()]:GetTechs():HasTech(GameInfo.Technologies["TECH_MASS_PRODUCTION"].Index);    -- check if a player researched Mass Production
-            if not CQUI_PlayerResearchedMassProduction then
-              CQUI_HousingFromImprovements = CQUI_HousingFromImprovements + 2;
-            else
-              CQUI_HousingFromImprovements = CQUI_HousingFromImprovements + 4;
+      if not kPlot:IsImprovementPillaged() then
+        local eImprovementType :number = kPlot:GetImprovementType();
+        if( eImprovementType ~= -1 ) then
+          local kImprovementData = GameInfo.Improvements[eImprovementType].Housing;
+          if kImprovementData == 1 then    -- farms, pastures etc.
+            CQUI_HousingFromImprovements = CQUI_HousingFromImprovements + 1;
+          elseif kImprovementData == 2 then    -- stepwells and kampungs
+            if GameInfo.Improvements[eImprovementType].ImprovementType == "IMPROVEMENT_STEPWELL" then    -- stepwells
+              local CQUI_PlayerResearchedSanitation :boolean = Players[Game.GetLocalPlayer()]:GetTechs():HasTech(GameInfo.Technologies["TECH_SANITATION"].Index);    -- check if a player researched Sanitation
+              if not CQUI_PlayerResearchedSanitation then
+                CQUI_HousingFromImprovements = CQUI_HousingFromImprovements + 2;
+              else
+                CQUI_HousingFromImprovements = CQUI_HousingFromImprovements + 4;
+              end
+            else    -- kampungs
+              local CQUI_PlayerResearchedMassProduction :boolean = Players[Game.GetLocalPlayer()]:GetTechs():HasTech(GameInfo.Technologies["TECH_MASS_PRODUCTION"].Index);    -- check if a player researched Mass Production
+              if not CQUI_PlayerResearchedMassProduction then
+                CQUI_HousingFromImprovements = CQUI_HousingFromImprovements + 2;
+              else
+                CQUI_HousingFromImprovements = CQUI_HousingFromImprovements + 4;
+              end
             end
           end
         end

--- a/Assets/UI/WorldView/citybannermanager.lua
+++ b/Assets/UI/WorldView/citybannermanager.lua
@@ -1130,7 +1130,7 @@ function CityBanner.UpdateStats( self : CityBanner)
 
         -- CQUI get real housing from improvements value
         local pCityID = pCity:GetID();
-        if CQUI_HousingUpdated[localPlayerID][pCityID] ~= true then
+        if CQUI_HousingUpdated[localPlayerID] == nil or CQUI_HousingUpdated[localPlayerID][pCityID] ~= true then
           CQUI_RealHousingFromImprovements(localPlayerID, pCityID);
         end
 

--- a/Assets/UI/WorldView/citybannermanager.lua
+++ b/Assets/UI/WorldView/citybannermanager.lua
@@ -2300,8 +2300,7 @@ function OnDistrictAddedToMap( playerID: number, districtID : number, cityID :nu
               	  if PlayerConfigurations[playerID]:GetCivilizationTypeName() == "CIVILIZATION_POLAND" then
               	    CQUI_OnCityInfoUpdated(playerID, cityID);
               	  end
-              	end
-              	if districtType == GameInfo.Districts["DISTRICT_HOLY_SITE"].Index or districtType == GameInfo.Districts["DISTRICT_LAVRA"].Index then
+              	elseif districtType == GameInfo.Districts["DISTRICT_HOLY_SITE"].Index or districtType == GameInfo.Districts["DISTRICT_LAVRA"].Index then
               	  if PlayerConfigurations[playerID]:GetCivilizationTypeName() == "CIVILIZATION_KHMER" then
               	    CQUI_OnCityInfoUpdated(playerID, cityID);
               	  else

--- a/Assets/UI/WorldView/citybannermanager.lua
+++ b/Assets/UI/WorldView/citybannermanager.lua
@@ -2293,6 +2293,42 @@ function OnDistrictAddedToMap( playerID: number, districtID : number, cityID :nu
               elseif (pDistrict:GetDefenseStrength() > 0 ) then
                 AddMiniBannerToMap( playerID, cityID, districtID, BANNERTYPE_ENCAMPMENT );
               end
+
+              -- CQUI update city's real housing from improvements when completed a district that triggers a Culture Bomb
+              if playerID == Game.GetLocalPlayer() then
+              	if districtType == GameInfo.Districts["DISTRICT_ENCAMPMENT"].Index then
+              	  if PlayerConfigurations[playerID]:GetCivilizationTypeName() == "CIVILIZATION_POLAND" then
+              	    CQUI_OnCityInfoUpdated(playerID, cityID);
+              	  end
+              	end
+              	if districtType == GameInfo.Districts["DISTRICT_HOLY_SITE"].Index or districtType == GameInfo.Districts["DISTRICT_LAVRA"].Index then
+              	  if PlayerConfigurations[playerID]:GetCivilizationTypeName() == "CIVILIZATION_KHMER" then
+              	    CQUI_OnCityInfoUpdated(playerID, cityID);
+              	  else
+              	    local playerReligion :table = pPlayer:GetReligion();
+              	    local playerReligionType :number = playerReligion:GetReligionTypeCreated();
+              	    if playerReligionType ~= -1 then
+              	      local cityReligion :table = pCity:GetReligion();
+              	      local eDominantReligion :number = cityReligion:GetMajorityReligion();
+              	      if eDominantReligion == playerReligionType then
+              	        local pGameReligion :table = Game.GetReligion();
+              	        local pAllReligions :table = pGameReligion:GetReligions();
+              	        for _, kFoundReligion in ipairs(pAllReligions) do
+              	          if kFoundReligion.Religion == eDominantReligion then
+              	            for _, belief in pairs(kFoundReligion.Beliefs) do
+              	              if GameInfo.Beliefs[belief].BeliefType == "BELIEF_BURIAL_GROUNDS" then
+              	                CQUI_OnCityInfoUpdated(playerID, cityID);
+              	                break;
+              	              end
+              	            end
+              	            break;
+              	          end
+              	        end
+              	      end
+              	    end
+              	  end
+              	end
+              end
             end
           else
             miniBanner:UpdateStats();

--- a/Assets/UI/WorldView/citybannermanager.lua
+++ b/Assets/UI/WorldView/citybannermanager.lua
@@ -2355,6 +2355,17 @@ function OnImprovementAddedToMap(locX, locY, eImprovementType, eOwner)
     return;
   end
 
+  -- CQUI update city's real housing from improvements when built an improvement that triggers a Culture Bomb
+  if eOwner == Game.GetLocalPlayer() then
+    if improvementData.ImprovementType == "IMPROVEMENT_FORT" then
+      if PlayerConfigurations[eOwner]:GetCivilizationTypeName() == "CIVILIZATION_POLAND" then
+        local ownerCity = Cities.GetPlotPurchaseCity(locX, locY);
+        local cityID = ownerCity:GetID();
+        CQUI_OnCityInfoUpdated(eOwner, cityID);
+      end
+    end
+  end
+
   -- Right now we're only interested in the Airstrip improvement
   if ( improvementData.AirSlots == 0 and improvementData.WeaponSlots == 0) then
     return;

--- a/Assets/UI/WorldView/citybannermanager.lua
+++ b/Assets/UI/WorldView/citybannermanager.lua
@@ -1130,12 +1130,12 @@ function CityBanner.UpdateStats( self : CityBanner)
 
         -- CQUI get real housing from improvements value
         local pCityID = pCity:GetID();
-        if CQUI_HousingUpdated[pCityID] ~= true then
+        if CQUI_HousingUpdated[localPlayerID][pCityID] ~= true then
           CQUI_RealHousingFromImprovements(localPlayerID, pCityID);
         end
 
         if g_smartbanner and g_smartbanner_population then
-          local CQUI_HousingFromImprovements = CQUI_HousingFromImprovementsTable[pCityID];    -- CQUI real housing from improvements value
+          local CQUI_HousingFromImprovements = CQUI_HousingFromImprovementsTable[localPlayerID][pCityID];    -- CQUI real housing from improvements value
           if CQUI_HousingFromImprovements ~= nil then    -- CQUI real housing from improvements fix to show correct values when waiting for the next turn
             local popTooltip:string = GetPopulationTooltip(self, turnsUntilGrowth, currentPopulation, foodSurplus);
             self.m_Instance.CityPopulation:SetToolTipString(popTooltip);

--- a/Assets/UI/WorldView/citybannermanager.lua
+++ b/Assets/UI/WorldView/citybannermanager.lua
@@ -3409,8 +3409,20 @@ function CQUI_OnAllCitiesInfoUpdated(PlayerID)
   local m_pCity:table = Players[PlayerID]:GetCities();
   for i, pCity in m_pCity:Members() do
     local pCityID = pCity:GetID();
-    CQUI_HousingUpdated[pCityID] = nil;
-    CQUI_RealHousingFromImprovements(PlayerID, pCityID)
+    CQUI_OnCityInfoUpdated(PlayerID, pCityID)
+  end
+end
+
+-- ===========================================================================
+-- CQUI update close to a culture bomb cities data and real housing from improvements
+function CQUI_OnCityLostTileToCultureBomb(PlayerID, x, y)
+  local m_pCity:table = Players[PlayerID]:GetCities();
+  for i, pCity in m_pCity:Members() do
+    if Map.GetPlotDistance( pCity:GetX(), pCity:GetY(), x, y ) <= 4 then
+      local pCityID = pCity:GetID();
+      CQUI_OnCityInfoUpdated(PlayerID, pCityID)
+      CityManager.RequestCommand(pCity, CityCommandTypes.SET_FOCUS, nil);
+    end
   end
 end
 
@@ -3489,6 +3501,7 @@ function Initialize()
 
   LuaEvents.CQUI_CityInfoUpdated.Add( CQUI_OnCityInfoUpdated );    -- CQUI update city's real housing from improvements
   LuaEvents.CQUI_AllCitiesInfoUpdated.Add( CQUI_OnAllCitiesInfoUpdated );    -- CQUI update all cities real housing from improvements
+  LuaEvents.CQUI_CityLostTileToCultureBomb.Add( CQUI_OnCityLostTileToCultureBomb );    -- CQUI update close to a culture bomb cities data and real housing from improvements
   Events.CityRemovedFromMap.Add( CQUI_OnCityRemovedFromMap );    -- CQUI erase real housing from improvements data everywhere when a city removed from map
 
   LuaEvents.GameDebug_Return.Add(OnGameDebugReturn);

--- a/Assets/UI/WorldView/citybannermanager.lua
+++ b/Assets/UI/WorldView/citybannermanager.lua
@@ -3377,7 +3377,7 @@ function CQUI_RealHousingFromImprovements(pCity)
             else
               CQUI_HousingFromImprovements = CQUI_HousingFromImprovements + 4;
             end
-          elseif GameInfo.Improvements[eImprovementType].ImprovementType == "IMPROVEMENT_KAMPUNG" then    -- kampungs
+          else    -- kampungs
             local CQUI_PlayerResearchedMassProduction :boolean = Players[Game.GetLocalPlayer()]:GetTechs():HasTech(GameInfo.Technologies["TECH_MASS_PRODUCTION"].Index);    -- check if a player researched Mass Production
             if not CQUI_PlayerResearchedMassProduction then
               CQUI_HousingFromImprovements = CQUI_HousingFromImprovements + 2;

--- a/Assets/UI/WorldView/citybannermanager.lua
+++ b/Assets/UI/WorldView/citybannermanager.lua
@@ -3437,8 +3437,14 @@ function CQUI_RealHousingFromImprovements(PlayerID, pCityID)
       end
     end
     CQUI_HousingFromImprovements = CQUI_HousingFromImprovements * 0.5;
-    CQUI_HousingFromImprovementsTable[pCityID] = CQUI_HousingFromImprovements;
-    CQUI_HousingUpdated[pCityID] = true;
+    if CQUI_HousingFromImprovementsTable[PlayerID] == nil then
+      CQUI_HousingFromImprovementsTable[PlayerID] = {};
+    end
+    if CQUI_HousingUpdated[PlayerID] == nil then
+      CQUI_HousingUpdated[PlayerID] = {};
+    end
+    CQUI_HousingFromImprovementsTable[PlayerID][pCityID] = CQUI_HousingFromImprovements;
+    CQUI_HousingUpdated[PlayerID][pCityID] = true;
     LuaEvents.CQUI_RealHousingFromImprovementsCalculated(pCityID, CQUI_HousingFromImprovements);
   end
 end
@@ -3446,7 +3452,7 @@ end
 -- ===========================================================================
 -- CQUI update city's real housing from improvements
 function CQUI_OnCityInfoUpdated(PlayerID, pCityID)
-  CQUI_HousingUpdated[pCityID] = nil;
+  CQUI_HousingUpdated[PlayerID][pCityID] = nil;
   CQUI_RealHousingFromImprovements(PlayerID, pCityID)
 end
 
@@ -3475,11 +3481,11 @@ end
 
 -- ===========================================================================
 -- CQUI erase real housing from improvements data everywhere when a city removed from map
-function CQUI_OnCityRemovedFromMap(playerID, cityID)
+function CQUI_OnCityRemovedFromMap(PlayerID, pCityID)
   if playerID == Game.GetLocalPlayer() then
-    CQUI_HousingFromImprovementsTable[cityID] = nil;
-    CQUI_HousingUpdated[cityID] = nil;
-    LuaEvents.CQUI_RealHousingFromImprovementsCalculated(cityID, nil);
+    CQUI_HousingFromImprovementsTable[PlayerID][pCityID] = nil;
+    CQUI_HousingUpdated[PlayerID][pCityID] = nil;
+    LuaEvents.CQUI_RealHousingFromImprovementsCalculated(pCityID, nil);
   end
 end
 

--- a/Assets/UI/WorldView/citybannermanager.lua
+++ b/Assets/UI/WorldView/citybannermanager.lua
@@ -3370,15 +3370,15 @@ function CQUI_RealHousingFromImprovements(pCity)
         if kImprovementData == 1 then    -- farms, pastures etc.
           CQUI_HousingFromImprovements = CQUI_HousingFromImprovements + 1;
         elseif kImprovementData == 2 then    -- stepwells and kampungs
-          if eImprovementType == 23 then    -- stepwells (Index == 23)
-            local CQUI_PlayerResearchedSanitation :boolean = Players[Game.GetLocalPlayer()]:GetTechs():HasTech(40);    -- check if a player researched Sanitation (Index == 40)
+          if GameInfo.Improvements[eImprovementType].ImprovementType == "IMPROVEMENT_STEPWELL" then    -- stepwells
+            local CQUI_PlayerResearchedSanitation :boolean = Players[Game.GetLocalPlayer()]:GetTechs():HasTech(GameInfo.Technologies["TECH_SANITATION"].Index);    -- check if a player researched Sanitation
             if not CQUI_PlayerResearchedSanitation then
               CQUI_HousingFromImprovements = CQUI_HousingFromImprovements + 2;
             else
               CQUI_HousingFromImprovements = CQUI_HousingFromImprovements + 4;
             end
-          else    -- kampungs (Index == 26, but after load a game Index == 25)
-            local CQUI_PlayerResearchedMassProduction :boolean = Players[Game.GetLocalPlayer()]:GetTechs():HasTech(27);    -- check if a player researched Mass Production (Index == 27)
+          elseif GameInfo.Improvements[eImprovementType].ImprovementType == "IMPROVEMENT_KAMPUNG" then    -- kampungs
+            local CQUI_PlayerResearchedMassProduction :boolean = Players[Game.GetLocalPlayer()]:GetTechs():HasTech(GameInfo.Technologies["TECH_MASS_PRODUCTION"].Index);    -- check if a player researched Mass Production
             if not CQUI_PlayerResearchedMassProduction then
               CQUI_HousingFromImprovements = CQUI_HousingFromImprovements + 2;
             else
@@ -3477,9 +3477,7 @@ function Initialize()
   Events.CityWorkerChanged.Add(           OnCityWorkerChanged );
 
   LuaEvents.CQUI_CityInfoUpdated.Add( CQUI_OnCityInfoUpdated );    -- CQUI update city's real housing from improvements
-  LuaEvents.CQUI_CityLostTileToCultureBomb.Add( CQUI_OnAllCitiesInfoUpdated );    -- CQUI update all cities real housing from improvements
-  LuaEvents.CQUI_IndiaPlayerResearchedSanitation.Add( CQUI_OnAllCitiesInfoUpdated );    -- CQUI update all cities real housing from improvements
-  LuaEvents.CQUI_IndonesiaPlayerResearchedMassProduction.Add( CQUI_OnAllCitiesInfoUpdated );    -- CQUI update all cities real housing from improvements
+  LuaEvents.CQUI_AllCitiesInfoUpdated.Add( CQUI_OnAllCitiesInfoUpdated );    -- CQUI update all cities real housing from improvements
 
   LuaEvents.GameDebug_Return.Add(OnGameDebugReturn);
 

--- a/Assets/UI/WorldView/plotinfo.lua
+++ b/Assets/UI/WorldView/plotinfo.lua
@@ -81,9 +81,9 @@ function OnClickSwapTile( plotId:number )
   local tResults :table = CityManager.RequestCommand( pSelectedCity, CityCommandTypes.SWAP_TILE_OWNER, tParameters );
 
   -- CQUI update citizens, data and real housing for both cities
-	CQUI_UpdateCitiesCitizensWhenSwapTiles(pSelectedCity);    -- CQUI update citizens and data for a city that is a new tile owner
-	local pCity = Cities.GetPlotPurchaseCity(kPlot);    -- CQUI a city that was a previous tile owner
-	CQUI_UpdateCitiesCitizensWhenSwapTiles(pCity);    -- CQUI update citizens and data for a city that was a previous tile owner
+  CQUI_UpdateCitiesCitizensWhenSwapTiles(pSelectedCity);    -- CQUI update citizens and data for a city that is a new tile owner
+  local pCity = Cities.GetPlotPurchaseCity(kPlot);    -- CQUI a city that was a previous tile owner
+  CQUI_UpdateCitiesCitizensWhenSwapTiles(pCity);    -- CQUI update citizens and data for a city that was a previous tile owner
   return true;
 end
 

--- a/Assets/UI/WorldView/plotinfo.lua
+++ b/Assets/UI/WorldView/plotinfo.lua
@@ -46,7 +46,6 @@ local CQUI_SmartWorkIconSize: number = 64;
 local CQUI_SmartWorkIconAlpha = .45;
 local CQUI_isMouseDragging = false;
 local CQUI_hasMouseDragged = false;
-local CQUI_SwapTileCity :table = {};    -- CQUI: a table we use to update data and real housing for cities when swap tiles
 
 function CQUI_OnSettingsUpdate()
   CQUI_WorkIconSize = GameConfiguration.GetValue("CQUI_WorkIconSize");
@@ -82,12 +81,9 @@ function OnClickSwapTile( plotId:number )
   local tResults :table = CityManager.RequestCommand( pSelectedCity, CityCommandTypes.SWAP_TILE_OWNER, tParameters );
 
   -- CQUI update citizens, data and real housing for both cities
-	local pSelectedCityID = pSelectedCity:GetID();    -- CQUI ID of a city that is a new tile owner
+	CQUI_UpdateCitiesCitizensWhenSwapTiles(pSelectedCity);    -- CQUI update citizens and data for a city that is a new tile owner
 	local pCity = Cities.GetPlotPurchaseCity(kPlot);    -- CQUI a city that was a previous tile owner
-	local pCityID = pCity:GetID();
-	CQUI_SwapTileCity[pSelectedCityID] = true;
-	CQUI_SwapTileCity[pCityID] = true;
-
+	CQUI_UpdateCitiesCitizensWhenSwapTiles(pCity);    -- CQUI update citizens and data for a city that was a previous tile owner
   return true;
 end
 
@@ -802,15 +798,6 @@ function OnCityTileOwnershipChanged(owner:number, cityID:number)
   if owner == Game.GetLocalPlayer() then
     RefreshPurchasePlots();
     RefreshCitizenManagement();
-
-		-- CQUI update citizens, data and real housing for both cities when swap tiles
-		if CQUI_SwapTileCity[cityID] == true then
-		  local pCity = CityManager.GetCity(owner, cityID);
-		  CityManager.RequestCommand(pCity, CityCommandTypes.SET_FOCUS, nil);
-		  CQUI_SwapTileCity[cityID] = nil;
-
-		  LuaEvents.CQUI_CityInfoUpdated(owner, cityID);
-		end
   end
 end
 
@@ -980,6 +967,16 @@ function OnInputHandler( pInputStruct:table )
   end
 
   return false;
+end
+
+-- ===========================================================================
+-- CQUI update citizens, data and real housing for both cities when swap tiles
+function CQUI_UpdateCitiesCitizensWhenSwapTiles(pCity)
+  CityManager.RequestCommand(pCity, CityCommandTypes.SET_FOCUS, nil);
+
+  local PlayerID = Game.GetLocalPlayer();
+  local pCityID = pCity:GetID();
+  LuaEvents.CQUI_CityInfoUpdated(PlayerID, pCityID);
 end
 
 -- ===========================================================================


### PR DESCRIPTION
Here we update all cities real housing when a tech that adds housing is boosted and research is completed during player's turn. Also made some code improvements to simplify it.
Upd: also fixed pillaged improvements were calculated for real housing.

Upd2: Reworked main function to calculate contaminated tiles correctly and to calculate real housing a bit faster. Also added some conditions to 'citypanel' and 'OnTileImproved' function to recalculate housing only for improvements with housing or when improvements are removed and to don't recalculate it when remove features or resources for examle. Improved housing updates when tile added or lost to a culture bomb. Added fix for Hot Seat games.